### PR TITLE
fixes for broken links devel branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The Red Hat Ansible Automation Linklight project is intended for effectively dem
 
 | Workshop   | Presentation Deck  | Exercises  | Workshop Type Var   |
 |---|---|---|---|
-| **Ansible Red Hat Enterprise Linux Workshop** <br>     focused on automating Linux platforms like Red Hat Enterprise Linux  | [Deck](https://ansible.github.io/linklight/decks/ansible-essentials.html)<br>[Ansible Tower](https://ansible.github.io/linklight/decks/tower_intro.pdf)  | [Exercises](./exercises/ansible_rhel)  | `workshop_type: rhel`  |
-| **Ansible Network Automation Workshop** <br> focused on router and switch platforms like Arista, Cisco, Juniper   | [Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf) | [Exercises](./exercises/ansible_network)  | `workshop_type: networking`  |
-| **Ansible F5 Workshop** <br> focused on automation of F5 BIG-IP  | [Deck](https://ansible.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](./exercises/ansible_f5)   | `workshop_type: f5` |
+| **Ansible Red Hat Enterprise Linux Workshop** <br>     focused on automating Linux platforms like Red Hat Enterprise Linux  | [Deck](https://ansible.github.io/workshops/decks/ansible-essentials.html)<br>[Ansible Tower](https://ansible.github.io/workshops/decks/tower_intro.pdf)  | [Exercises](./exercises/ansible_rhel)  | `workshop_type: rhel`  |
+| **Ansible Network Automation Workshop** <br> focused on router and switch platforms like Arista, Cisco, Juniper   | [Deck](https://ansible.github.io/workshops/decks/ansible_network.pdf) | [Exercises](./exercises/ansible_network)  | `workshop_type: networking`  |
+| **Ansible F5 Workshop** <br> focused on automation of F5 BIG-IP  | [Deck](https://ansible.github.io/workshops/decks/ansible_f5.pdf) | [Exercises](./exercises/ansible_f5)   | `workshop_type: f5` |
 
 ## LAB PROVISIONER
  - [AWS Lab Provisioner](provisioner) - playbook that spins up instances on AWS for students to perform the exercises provided above.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The Red Hat Ansible Automation Linklight project is intended for effectively dem
 
 | Workshop   | Presentation Deck  | Exercises  | Workshop Type Var   |
 |---|---|---|---|
-| **Ansible Red Hat Enterprise Linux Workshop** <br>     focused on automating Linux platforms like Red Hat Enterprise Linux  | [Deck](https://network-automation.github.io/linklight/decks/ansible-essentials.html)<br>[Ansible Tower](https://network-automation.github.io/linklight/decks/tower_intro.pdf)  | [Exercises](./exercises/ansible_rhel)  | `workshop_type: rhel`  |
-| **Ansible Network Automation Workshop** <br> focused on router and switch platforms like Arista, Cisco, Juniper   | [Deck](https://network-automation.github.io/linklight/decks/ansible_network.pdf) | [Exercises](./exercises/ansible_network)  | `workshop_type: networking`  |
-| **Ansible F5 Workshop** <br> focused on automation of F5 BIG-IP  | [Deck](https://network-automation.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](./exercises/ansible_f5)   | `workshop_type: f5` |
+| **Ansible Red Hat Enterprise Linux Workshop** <br>     focused on automating Linux platforms like Red Hat Enterprise Linux  | [Deck](https://ansible.github.io/linklight/decks/ansible-essentials.html)<br>[Ansible Tower](https://ansible.github.io/linklight/decks/tower_intro.pdf)  | [Exercises](./exercises/ansible_rhel)  | `workshop_type: rhel`  |
+| **Ansible Network Automation Workshop** <br> focused on router and switch platforms like Arista, Cisco, Juniper   | [Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf) | [Exercises](./exercises/ansible_network)  | `workshop_type: networking`  |
+| **Ansible F5 Workshop** <br> focused on automation of F5 BIG-IP  | [Deck](https://ansible.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](./exercises/ansible_f5)   | `workshop_type: f5` |
 
 ## LAB PROVISIONER
  - [AWS Lab Provisioner](provisioner) - playbook that spins up instances on AWS for students to perform the exercises provided above.

--- a/exercises/ansible_network/README.md
+++ b/exercises/ansible_network/README.md
@@ -4,7 +4,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible's 
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Ansible Network Automation Workshop Deck](https://network-automation.github.io/linklight/decks/ansible_network.pdf)
+[Ansible Network Automation Workshop Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf)
 
 ## Ansible Network Automation Exercises
 

--- a/exercises/ansible_network/archive/README.md
+++ b/exercises/ansible_network/archive/README.md
@@ -4,7 +4,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible's 
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Ansible Network Automation Workshop Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf)
+[Ansible Network Automation Workshop Deck](https://ansible.github.io/workshops/decks/ansible_network.pdf)
 
 ## Ansible Network Automation Exercises
 

--- a/exercises/ansible_network/archive/README.md
+++ b/exercises/ansible_network/archive/README.md
@@ -4,7 +4,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible's 
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Ansible Network Automation Workshop Deck](https://network-automation.github.io/linklight/decks/ansible_network.pdf)
+[Ansible Network Automation Workshop Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf)
 
 ## Ansible Network Automation Exercises
 

--- a/exercises/ansible_tower/README.md
+++ b/exercises/ansible_tower/README.md
@@ -6,7 +6,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible To
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Intro to Ansible Tower Deck](https://ansible.github.io/linklight/decks/tower_intro.pdf)
+[Intro to Ansible Tower Deck](https://ansible.github.io/workshops/decks/tower_intro.pdf)
 
 ## Ansible Red Hat Enterprise Linux Exercises
 

--- a/exercises/ansible_tower/README.md
+++ b/exercises/ansible_tower/README.md
@@ -6,7 +6,7 @@ This content is a multi-purpose toolkit for effectively demonstrating Ansible To
 
 ## Presentation
 Want the Presentation Deck?  Its right here:
-[Intro to Ansible Tower Deck](https://network-automation.github.io/linklight/decks/tower_intro.pdf)
+[Intro to Ansible Tower Deck](https://ansible.github.io/linklight/decks/tower_intro.pdf)
 
 ## Ansible Red Hat Enterprise Linux Exercises
 

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -3,9 +3,9 @@
 
 | Workshop   | Deck  | Exercises  | Workshop Type Var   |
 |---|---|---|---|
-| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://network-automation.github.io/linklight/decks/ansible-essentials.html)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
-| Ansible Network Automation Workshop  | [Deck](https://network-automation.github.io/linklight/decks/ansible_network.pdf) | [Exercises](../exercises/ansible_network)  | `workshop_type: networking`  |
-| Ansible F5 Workshop | [Deck](https://network-automation.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](../exercises/ansible_f5)   | `workshop_type: f5`   |
+| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://ansible.github.io/linklight/decks/ansible-essentials.html)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
+| Ansible Network Automation Workshop  | [Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf) | [Exercises](../exercises/ansible_network)  | `workshop_type: networking`  |
+| Ansible F5 Workshop | [Deck](https://ansible.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](../exercises/ansible_f5)   | `workshop_type: f5`   |
 
 
 # Table Of Contents

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -3,9 +3,9 @@
 
 | Workshop   | Deck  | Exercises  | Workshop Type Var   |
 |---|---|---|---|
-| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://ansible.github.io/linklight/decks/ansible-essentials.html)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
-| Ansible Network Automation Workshop  | [Deck](https://ansible.github.io/linklight/decks/ansible_network.pdf) | [Exercises](../exercises/ansible_network)  | `workshop_type: networking`  |
-| Ansible F5 Workshop | [Deck](https://ansible.github.io/linklight/decks/ansible_f5.pdf) | [Exercises](../exercises/ansible_f5)   | `workshop_type: f5`   |
+| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://ansible.github.io/workshops/decks/ansible-essentials.html)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
+| Ansible Network Automation Workshop  | [Deck](https://ansible.github.io/workshops/decks/ansible_network.pdf) | [Exercises](../exercises/ansible_network)  | `workshop_type: networking`  |
+| Ansible F5 Workshop | [Deck](https://ansible.github.io/workshops/decks/ansible_f5.pdf) | [Exercises](../exercises/ansible_f5)   | `workshop_type: f5`   |
 
 
 # Table Of Contents

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -247,31 +247,31 @@ $("document").ready(function(){
           </div>
 
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible_network.pdf">Ansible Network Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/decks/ansible_network.pdf">Ansible Network Deck</a>
           </div>
 
         </div>
         {% elif workshop_type == "f5" %}
         <div class="row">
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_f5/">Ansible F5 Exercises</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/exercises/ansible_f5/">Ansible F5 Exercises</a>
           </div>
 
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible_f5.pdf">Ansible F5 Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/decks/ansible_f5.pdf">Ansible F5 Deck</a>
           </div>
 
         </div>
         {% else %}
          <div class="row">
             <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_rhel/">Ansible Server Exercises</a>
+                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/exercises/ansible_rhel/">Ansible Server Exercises</a>
             </div>
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible-essentials.html#/">Ansible Essentials Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/decks/ansible-essentials.html#/">Ansible Essentials Deck</a>
           </div>
             <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_tower/">Ansible Tower Exercises</a>
+                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/exercises/ansible_tower/">Ansible Tower Exercises</a>
             </div>
 
         </div>

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -243,35 +243,35 @@ $("document").ready(function(){
         {% if workshop_type == "networking" %}
         <div class="row">
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_network">Ansible Network Exercises</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/exercises/ansible_network/">Ansible Network Exercises</a>
           </div>
 
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible_network.pdf">Ansible Network Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible_network.pdf">Ansible Network Deck</a>
           </div>
 
         </div>
         {% elif workshop_type == "f5" %}
         <div class="row">
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_f5/">Ansible F5 Exercises</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_f5/">Ansible F5 Exercises</a>
           </div>
 
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible_f5.pdf">Ansible F5 Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible_f5.pdf">Ansible F5 Deck</a>
           </div>
 
         </div>
         {% else %}
          <div class="row">
             <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_rhel/">Ansible Server Exercises</a>
+                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_rhel/">Ansible Server Exercises</a>
             </div>
           <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/decks/ansible-essentials.html#/">Ansible Essentials Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/decks/ansible-essentials.html#/">Ansible Essentials Deck</a>
           </div>
             <div class="col-sm-4">
-                <a class="btn btn-secondary btn-block" href="https://network-automation.github.io/linklight/exercises/ansible_tower/">Ansible Tower Exercises</a>
+                <a class="btn btn-secondary btn-block" href="https://ansible.github.io/linklight/exercises/ansible_tower/">Ansible Tower Exercises</a>
             </div>
 
         </div>


### PR DESCRIPTION
##### SUMMARY
fixes for bug https://github.com/ansible/workshops/issues/268

the network-automation.github.io pages are not redirecting, everything else is redirecting fine

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
links... lots of links and the PDF

##### ADDITIONAL INFORMATION
this is confusing users of the content from the auto-generated startup page and docs
