### PR TITLE
One Time Setup documentation: Merge pip installs into a single step. 

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,14 +21,14 @@ aws_access_key_id = ABCDEFGHIJKLMNOP
 aws_secret_access_key = ABCDEFGHIJKLMNOP/ABCDEFGHIJKLMNOP
 ```
 
-6. Clone the linklight repo:
+5. Clone the linklight repo:
 
 If you haven't done so already make sure you have the repo cloned to the machine executing the playbook
 
         git clone https://github.com/network-automation/linklight.git
         cd linklight/provisioner
 
-7.  When doing a networking or F5 workshop make sure you have subscribed to the right marketplace AMI (Amazon Machine Image)
+6.  When doing a networking or F5 workshop make sure you have subscribed to the right marketplace AMI (Amazon Machine Image)
 
   - For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/)
   - For F5 you will need the F5 BIG-IP [Click here](https://aws.amazon.com/marketplace/pp/B079C44MFH/)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,9 +6,9 @@
 
   - New to AWS and not sure what this step means?  [Click here](aws-directions/AWSHELP.md)
 
-3. Install `boto` and `boto3`as well as `netaddr`
+3. Install `boto` and `boto3`as well as `netaddr` and `passlib`
 
-        pip install boto boto3 netaddr
+        pip install boto boto3 netaddr passlib
 
   **Are you using Tower?**  [Tower Instructions](#tower-instructions)
 
@@ -20,10 +20,6 @@
 aws_access_key_id = ABCDEFGHIJKLMNOP
 aws_secret_access_key = ABCDEFGHIJKLMNOP/ABCDEFGHIJKLMNOP
 ```
-
-5. Install the `passlib` library and `netaddr`
-
-        pip install passlib netaddr
 
 6. Clone the linklight repo:
 


### PR DESCRIPTION
##### SUMMARY
Is there any reason for having two different `pip installs`? `netaddr` was both in step 3 and 5, and we could move `passlib` to step 1 so we just issue a single install command. 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
One time setup documentation. 

##### ADDITIONAL INFORMATION
Minor change. 
