### PR TITLE
populate_tower: Execute on the controle_nodes

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -206,7 +206,6 @@
 
 - name: POPULATE TOWER STEP ONE
   hosts: control_nodes
-  connection: local
   gather_facts: no
 
   tasks:
@@ -239,7 +238,6 @@
 
 - name: TOWER JOB TEMPLATES IN PLAYBOOK FORM
   hosts: control_nodes
-  connection: local
   gather_facts: no
 
   tasks:


### PR DESCRIPTION
Currently both populate_tower_step one and populate_tower_step_three are
run from the Ansible controller (`connection: local`) and not the
control_nodes.

However the required packages to run the Ansible Tower modules are
installed on the control_nodes but not on the Ansible controller[1]

In its current form, this leads to the following error

```
TASK [populate_tower : CREATE NETWORK ORGANIZATION]
****************************
An exception occurred during task execution. To see the full traceback,
use -vvv. The error was: ImportError: No module named tower_cli.utils.exceptions
fatal: [tower-qe-networking-student1-ansible]: FAILED! => changed=false
  msg: Failed to import the required Python library (********-tower-cli)
on XXX. Please read module documentation and install in the appropriate location
```

[1]
https://github.com/ansible/workshops/blob/devel/provisioner/roles/control_node/tasks/tower.yml#L26-L32