### PR TITLE
Ipv sean/snow enchancements

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -34,6 +34,19 @@
         that:
           - ec2_name_prefix != "TESTWORKSHOP"
 
+    - name: make sure packages required are installed on this control node
+      pip:
+        name:
+          - netaddr
+      check_mode: yes
+      when: workshop_type == "networking"
+      register: package_state
+
+    - name: fail if previous check has changed
+      assert:
+        that:
+          - package_state.changed != True
+
     - name: auto license feature for Ansible Tower
       block:
         - name: Check that the provided license exists

--- a/provisioner/roles/aws_dns/tasks/main.yml
+++ b/provisioner/roles/aws_dns/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: CHECK TO SEE IF SSL CERT ALREADY APPLIED
   uri:
-    url: https://localhost/api/v2/ping/
+    url: "https://{{username}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}/api/v2/ping/"
     method: GET
     user: admin
     password: ansible

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -56,57 +56,32 @@
     repo: https://github.com/network-automation/linklight.git
     force: yes
 
-# This is waiting on https://github.com/ansible/ansible/pull/41222
-# which will become available on ansible 2.8
-# - name: Move networking workshop folder to correct location  (NETWORKING MODE)
-#   copy:
-#     src: /tmp/linklight/exercises/ansible_network/
-#     dest: /home/{{ username }}/networking-workshop
-#     remote_src: yes
-#   when: workshop_type == 'networking'
-
 - name: Move networking workshop folder to correct location  (NETWORKING MODE)
-  command: cp -r /tmp/linklight/exercises/ansible_network/ /home/{{ username }}/networking-workshop/
+  copy:
+    src: /tmp/linklight/exercises/ansible_network/
+    dest: /home/{{ username }}/networking-workshop
+    remote_src: yes
+    owner: "{{ username }}"
+    group: "{{ username }}"
   when: workshop_type == 'networking'
-
-# This is waiting on https://github.com/ansible/ansible/pull/41222
-# which will become available on ansible 2.8
-# - name: Create demos folder with demos
-#   copy:
-#     src: /tmp/linklight/demos/
-#     dest: /home/{{ username }}/demos
-#     remote_src: yes
-#   when: workshop_type == 'networking'
 
 - name: Create demos folder with demos
-  command: cp -r /tmp/linklight/demos/ /home/{{ username }}/demos
+  copy:
+    src: /tmp/linklight/demos/
+    dest: /home/{{ username }}/demos
+    remote_src: yes
+    owner: "{{ username }}"
+    group: "{{ username }}"
   when: workshop_type == 'networking'
 
-# This is waiting on https://github.com/ansible/ansible/pull/41222
-# which will become available on ansible 2.8
-# - name: Move networking workshop folder to correct location  (F5 MODE)
-#   copy:
-#     src: /{{playbook_dir}}/linklight/exercises/ansible_f5/
-#     dest: /home/{{ username }}/networking-workshop
-#   when: workshop_type == 'f5'
-
 - name: Move networking workshop folder to correct location  (F5 MODE)
-  shell: mkdir /home/{{ username }}/networking-workshop; cp -r /tmp/linklight/exercises/ansible_f5/* /home/{{ username }}/networking-workshop
+  copy:
+    src: /tmp/linklight/exercises/ansible_f5/
+    dest: /home/{{ username }}/networking-workshop
+    remote_src: yes
+    owner: "{{ username }}"
+    group: "{{ username }}"
   when: workshop_type == 'f5'
-
-- name: fix permissions of networking-workshop  (NETWORKING MODE)
-  file:
-    path: /home/{{ username }}/networking-workshop
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    recurse: yes
-
-- name: fix permissions of demos  (NETWORKING MODE)
-  file:
-    path: /home/{{ username }}/demos
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    recurse: yes
 
 - name: Create lab inventory directory (NETWORKING MODE)
   file:

--- a/provisioner/tests/setup_f5_tower.yml
+++ b/provisioner/tests/setup_f5_tower.yml
@@ -23,6 +23,7 @@
         organization: Default
         tower_config_file: "~/tower_cli.cfg"
 
+    - name: CREATE F5 ADDNODE JOB TEMPLATE
       tower_job_template:
         name: "F5 add nodes"
         job_type: "run"

--- a/provisioner/tests/setup_f5_tower.yml
+++ b/provisioner/tests/setup_f5_tower.yml
@@ -23,7 +23,6 @@
         organization: Default
         tower_config_file: "~/tower_cli.cfg"
 
-    - name: CREATE F5 ADDNODE JOB TEMPLATE
       tower_job_template:
         name: "F5 add nodes"
         job_type: "run"


### PR DESCRIPTION
##### SUMMARY

- checks for netaddr for control node, for the `workshop_type: networking `
- will not run DNS lets encrypt if it already is working (file provisioner/roles/aws_dns/tasks/main.yml)
- reduced complexity of `provisioner/roles/control_node/tasks/networking.yml` for new module parameters available in ansible 2.8

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
provisioner features/enhancements 

##### ADDITIONAL INFORMATION
n/a
