### PR TITLE
Remove lightbulb name from RHEL workshop

### DIFF
--- a/exercises/ansible_rhel/1.2-adhoc/README.md
+++ b/exercises/ansible_rhel/1.2-adhoc/README.md
@@ -76,7 +76,7 @@ timeout = 60
 deprecation_warnings = False
 host_key_checking = False
 retry_files_enabled = False
-inventory = /home/student<X>/lightbulb/lessons/lab_inventory/student1-instances.txt
+inventory = /home/student<X>/lab_inventory/hosts
 ```
 
 There are multiple configuration flags provided. Most of them are not of interest here, but make sure to note the last line: there the location of the inventory is provided. That is the way Ansible knew in the previous commands what machines to connect to.
@@ -84,7 +84,7 @@ There are multiple configuration flags provided. Most of them are not of interes
 Output the content of your dedicated inventory to proof-read 
 
 ```bash
-[student<X>@ansible ~]$ cat /home/student<X>/lightbulb/lessons/lab_inventory/student<X>-instances.txt
+[student<X>@ansible ~]$ cat /home/student<X>/lab_inventory/hosts
 [all:vars]
 ansible_user=student<X>
 ansible_ssh_pass=ansible
@@ -107,7 +107,7 @@ ansible ansible_host=44.55.66.77
 
 > **Warning**
 > 
-> **Don’t forget to run the commands from the home directory of your student user, `/home/student\<X\>`. THat is where your `.ansible.cfg` file is located, without it Ansible will not know what which inventory to use.**
+> **Don’t forget to run the commands from the home directory of your student user, `/home/student\<X\>`. That is where your `.ansible.cfg` file is located, without it Ansible will not know what which inventory to use.**
 
 Let's start with something really basic - pinging a host. To do that we use the Ansible `ping` module. The `ping` module makes sure our web hosts are responsive. Basically, it connects to the managed host, executes a small script there and collects the results. That way it is ensured that the managed host is reachable and that Ansible is able to execute commands properly on it.
 

--- a/exercises/ansible_rhel/1.3-playbook/README.md
+++ b/exercises/ansible_rhel/1.3-playbook/README.md
@@ -130,7 +130,7 @@ The output should not report any errors but provide an overview of the tasks exe
 Use SSH to make sure Apache has been installed on node1. The necessary IP address is provided in the inventory. Grep for the IP address there and use it to SSH to the node.
 
 ```bash
-[student<X>@ansible ansible-files]$ grep node1 ~/lightbulb/lessons/lab_inventory/student<X>-instances.txt
+[student<X>@ansible ansible-files]$ grep node1 ~/lab_inventory/hosts
 node1 ansible_host=11.22.33.44
 [student<X>@ansible ansible-files]$ ssh 11.22.33.44
 student<X>@11.22.33.44's password: 

--- a/exercises/ansible_rhel/1.4-variables/README.md
+++ b/exercises/ansible_rhel/1.4-variables/README.md
@@ -115,7 +115,7 @@ Create a new Playbook called `deploy_index_html.yml` in the `~/ansible-files/` d
 The Playbook should copy different files as index.html to the hosts, use `curl` to test it. Check the inventory again if you forgot the IP addresses of your nodes.
 
 ```bash
-[student<X>@ansible ansible-files]$ grep node ~/lightbulb/lessons/lab_inventory/student<X>-instances.txt
+[student<X>@ansible ansible-files]$ grep node ~/lab_inventory/hosts
 node1 ansible_host=11.22.33.44
 node2 ansible_host=22.33.44.55
 node3 ansible_host=33.44.55.66

--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -19,7 +19,7 @@ For more on this, please refer to the documentation: <http://jinja.pocoo.org/doc
 
 As an example you would like to install an FTP server, but only on hosts that are in the "ftpserver" inventory group.
 
-To do that, first edit the inventory to add another group, and place `node2` in it. Make sure that that IP address of `node2` is always the same when `node2` is listed. Edit the inventory `~/lightbulb/lessons/lab_inventory/student\<X\>1-instances.txt` to look like the following listing:
+To do that, first edit the inventory to add another group, and place `node2` in it. Make sure that that IP address of `node2` is always the same when `node2` is listed. Edit the inventory `~/lab_inventory/hosts` to look like the following listing:
 
 ```ini
 [all:vars]

--- a/provisioner/roles/control_node/defaults/main.yml
+++ b/provisioner/roles/control_node/defaults/main.yml
@@ -1,2 +1,1 @@
-control_node_inventory_path: ~{{ username }}/lightbulb/lessons/lab_inventory/{{ username }}-instances.txt
 xrdp: false

--- a/provisioner/roles/control_node/tasks/rhel.yml
+++ b/provisioner/roles/control_node/tasks/rhel.yml
@@ -1,31 +1,12 @@
-- name: Clone lightbulb
-  git:
-    accept_hostkey: yes
-    clone: yes
-    dest: /home/{{ username }}/lightbulb
-    repo: https://github.com/ansible/lightbulb.git
-    force: yes
-  become_user: "{{ username }}"
-
-- name: Remove things that students don't need
-  file:
-    state: absent
-    path: /home/{{ username }}/lightbulb/{{ item }}
-  with_items:
-    - aws_lab_setup
-    - resources
-    - Vagrantfile
-    - README.md
-
 - name: Create lab inventory directory
   file:
     state: directory
-    path: /home/{{ username }}/lightbulb/lessons/lab_inventory
+    path: /home/{{ username }}/lab_inventory
 
 - name: Put student inventory in proper spot
   copy:
     src: ./{{ec2_name_prefix}}/{{ username }}-instances.txt
-    dest: "{{ control_node_inventory_path }}"
+    dest: /home/{{ username }}/lab_inventory/hosts
     owner: "{{ username }}"
     group: "{{ username }}"
   when: username in inventory_hostname

--- a/provisioner/roles/control_node/templates/ansible.cfg.j2
+++ b/provisioner/roles/control_node/templates/ansible.cfg.j2
@@ -6,7 +6,7 @@ deprecation_warnings = False
 host_key_checking = False
 retry_files_enabled = False
 {% if workshop_type == 'rhel' %}
-inventory = /home/{{username}}/lightbulb/lessons/lab_inventory/{{username}}-instances.txt
+inventory = /home/{{username}}/lab_inventory/hosts
 {% else %}
 inventory = /home/{{username}}/networking-workshop/lab_inventory/hosts
 [persistent_connection]


### PR DESCRIPTION
- change RHEL provisioner to not check out lightbulb repo at all
- change RHEL provisioner to copy inventory to ~/lab_inventory/
- change RHEL provisioner to rename inventory from
student<X>-instances.txt to hosts
- change RHEL exercises to always refer to new inventory

##### SUMMARY

The RHEL workshop still did a checkout of the lightbulb repo, though we have no use of that anymore. Also, the inventory was copied to a weird place in this checkout instead of into a sensible position.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

RHEL workshop
