### PR TITLE
Change import_role to include_role

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -209,13 +209,13 @@
   tasks:
     - block:
       - name: setup epel for snort ecosystem rule lifecycling
-        import_role:
+        include_role:
           name: "geerlingguy.repo-epel"
       - name: import ids_install role
-        import_role:
+        include_role:
           name: "ansible_security.ids_install"
       - name: import ids_config role
-        import_role:
+        include_role:
           name: "ansible_security.ids_config"
       when:
         - workshop_type == "security"


### PR DESCRIPTION
##### SUMMARY

Change `import_role` to `include_role`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Security

##### ADDITIONAL INFORMATION

import_role only works if roles are already installed by other means. include works also if role was never installed.