### PR TITLE
Security: Deactivate etchosts copy since we do not have it right now

### DIFF
--- a/provisioner/roles/control_node/tasks/security.yml
+++ b/provisioner/roles/control_node/tasks/security.yml
@@ -129,9 +129,11 @@
     group: "{{ansible_user}}"
     mode: 0700
 
-- name: setup /etc/hosts file per student
-  copy:
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
-    dest: "/etc/hosts"
-    owner: "{{ username }}"
-    group: "{{ username }}"
+# FIXME - MAKE A SECURITY AUTOMATION ONE OF THESE - IF NEEDED
+#
+#- name: setup /etc/hosts file per student
+#  copy:
+#    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
+#    dest: "/etc/hosts"
+#    owner: "{{ username }}"
+#    group: "{{ username }}"


### PR DESCRIPTION
##### SUMMARY

Currently in security we try to copy a etchosts file to the control host - but don't have one. This PR comments out this specific task.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Security

##### ADDITIONAL INFORMATION

Error in normal execution is:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [RWOLTERS-SPLUNK-student1-ansible]: FAILED! => changed=false 
  msg: |-
    Could not find or access '/home/rwolters/gits/github/liquidat/workshops/provisioner/RWOLTERS-SPLUNK/student1-etchosts.txt' on the Ansible Controller.
    If you are using a module and expect the file to exist on the remote, see the remote_src option
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: If you are using a module and expect the file to exist on the remote, see the remote_src option
fatal: [RWOLTERS-SPLUNK-student2-ansible]: FAILED! => changed=false 
  msg: |-
    Could not find or access '/home/rwolters/gits/github/liquidat/workshops/provisioner/RWOLTERS-SPLUNK/student2-etchosts.txt' on the Ansible Controller.
    If you are using a module and expect the file to exist on the remote, see the remote_src option
```

Problem: in that file the last task is to copy a etc hosts file. But we do not create one in security - like the networking does in the `addhost_` task files.
