### PR TITLE
Ensure TESTWORKSHOP as name prefix example

### DIFF
--- a/provisioner/sample_workshops/sample-cisco.yml
+++ b/provisioner/sample_workshops/sample-cisco.yml
@@ -2,7 +2,7 @@
 # region where the nodes will live
 ec2_region: us-east-2
 # name prefix for all the VMs
-ec2_name_prefix: CISCO-TEST
+ec2_name_prefix: TESTWORKSHOP
 admin_password: ansible
 student_total: 2
 workshop_type: networking

--- a/provisioner/sample_workshops/sample-juniper.yml
+++ b/provisioner/sample_workshops/sample-juniper.yml
@@ -2,7 +2,7 @@
 # region where the nodes will live
 ec2_region: us-east-2
 # name prefix for all the VMs
-ec2_name_prefix: JUNIPER-TEST
+ec2_name_prefix: TESTWORKSHOP
 admin_password: ansible
 student_total: 2
 workshop_type: networking

--- a/provisioner/sample_workshops/sample-multivendor.yml
+++ b/provisioner/sample_workshops/sample-multivendor.yml
@@ -2,7 +2,7 @@
 # region where the nodes will live
 ec2_region: us-east-2
 # name prefix for all the VMs
-ec2_name_prefix: MULTIVENDOR-TEST
+ec2_name_prefix: TESTWORKSHOP
 admin_password: ansible
 student_total: 2
 workshop_type: networking

--- a/provisioner/sample_workshops/sample-security.yml
+++ b/provisioner/sample_workshops/sample-security.yml
@@ -1,7 +1,11 @@
-workshop_type: 'security'
+# region where the nodes will live
 ec2_region: us-east-1
-ec2_name_prefix: securitysample
+# name prefix for all the VMs
+ec2_name_prefix: TESTWORKSHOP
+# amount of work benches to provision
 student_total: 2
+# workshop is put into isecurity mode
+workshop_type: 'security'
 ## Optional Variables
 admin_password: ansible
 create_login_page: false


### PR DESCRIPTION
##### SUMMARY

Ensure `TESTWORKSHOP` in all `sample-vars*` so that basic [sanity check in `provision_lab`](https://github.com/ansible/workshops/blob/13210c7af9804a0407b857736e0bc2956ddb281f/provisioner/provision_lab.yml#L33) works and prevents that multiple people launch workshop with the same name.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ALL

##### ADDITIONAL INFORMATION

In theory, multiple people can launch workshops with the same names, thus mixing the workshops in a dangerous way. To prevent that we have [a security check in `provision_lab.yml`](https://github.com/ansible/workshops/blob/13210c7af9804a0407b857736e0bc2956ddb281f/provisioner/provision_lab.yml#L33) that ensures that people put their on workshop name prefix in the vars file:

```
    - name: make sure we are not running with TESTWORKSHOP as the name so no overlap
      assert:
        that:
          - ec2_name_prefix != "TESTWORKSHOP"
```

However, that only works if all our sample files actually use the name prefix example "TESTWORKSHOP". This PR makes sure of that.