### PR TITLE
Add security roles to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ demos/servicenow/private.yml
 *.html
 demos/servicenow/closed_loop_incident_mgmt/input_vars.yaml
 demos/servicenow/closed_loop_incident_mgmt/snow_demo2/snow_vars.yaml
+provisioner/roles/ansible_security.ids_config/
+provisioner/roles/ansible_security.ids_install/
+provisioner/roles/geerlingguy.repo-epel/


### PR DESCRIPTION
##### SUMMARY

Security workshop automatically downloads and applies some galaxy roles.
To avoid having them added to the repo on accident I added them to `.gitignore`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Security / gitignore
