### PR TITLE
2.0-disable-pool-member: Fix invalid task name

### DIFF
--- a/exercises/ansible_f5/2.0-disable-pool-member/disable-pool-member.yml
+++ b/exercises/ansible_f5/2.0-disable-pool-member/disable-pool-member.yml
@@ -55,7 +55,7 @@
      query_string: "[?name=='{{pool_name}}'].members[*].name[]"
     when: '"all" in member_name.user_input'
 
-  - name: Disable pool member {{member_name.user_input}}
+  - name: "Disable pool member {{member_name.user_input}}"
     bigip_pool_member:
       provider: "{{provider}}"
       state: "forced_offline"


### PR DESCRIPTION
```
TASK [Disable pool member]
*****************************************************
fatal: [f5]: FAILED! =>
  msg: |-
    The task includes an option with an undefined variable. The error
was: list object has no element 1

    The error appears to be in
'/home/student1/networking-workshop/2.0-disable-pool-member/disable-pool-member.yml': line 58, column 5, but may
    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

      - name: Disable pool member {{member_name.user_input}}
        ^ here
    We could be wrong, but this one looks like it might be an issue with
    missing quotes. Always quote template expression brackets when they
    start a value. For instance:

        with_items:
          - {{ foo  }}

    Should be written as:

        with_items:
          - "{{ foo  }}"
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the role, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
