### PR TITLE
Line 36 - missing ` for `control` so added it

### DIFF
--- a/exercises/ansible_rhel/1.2-adhoc/README.md
+++ b/exercises/ansible_rhel/1.2-adhoc/README.md
@@ -33,7 +33,7 @@ The most basic host pattern is the name for a single managed host listed in the 
     node1
 ```
 
-An inventory file can contain a lot more information, it can organize your hosts in groups or define variables. In our example, the current inventory has the groups `web` and `control. Run Ansible with these host patterns and observe the output:
+An inventory file can contain a lot more information, it can organize your hosts in groups or define variables. In our example, the current inventory has the groups `web` and `control`. Run Ansible with these host patterns and observe the output:
 
 ```bash
 [student<X@>ansible ~]$ ansible web  --list-hosts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Reading through the exercises noticed that `control` was missing the closing `. So added that change.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


