### PR TITLE
Use pause module instead of prompts module

### DIFF
--- a/exercises/ansible_f5/2.0-disable-pool-member/README.md
+++ b/exercises/ansible_f5/2.0-disable-pool-member/README.md
@@ -133,7 +133,7 @@ Next, add a task for the objective listed below:
   - Prompt the user to enter a Host:Port to disable a particular member or 'all' to disable all members
 
 HINT:
-Use the <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_prompts.html" style="color: #000000">prompts</a> module</a></span>
+Use the <a href="https://docs.ansible.com/ansible/latest/modules/pause_module.html" style="color: #000000">pause</a> module</a></span>
 
 ## Step 9
 Next, add a task for the objective listed below:


### PR DESCRIPTION

##### SUMMARY

prompt module cannot be used inside a task.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- exercises

##### ADDITIONAL INFORMATION

All I have found about prompting for user input inside a task is pause module and a contribution to Ansible Galaxy https://galaxy.ansible.com/andrewvaughan/prompt
