### PR TITLE
Update 1.x with provider and bigip_wait to provisioner

### DIFF
--- a/exercises/ansible_f5/1.2-add-node/README.md
+++ b/exercises/ansible_f5/1.2-add-node/README.md
@@ -58,13 +58,14 @@ Next, add the first `task`. This task will use the `bigip_node` module configure
 
   - name: CREATE NODES
     bigip_node:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       host: "{{hostvars[item].ansible_host}}"
       name: "{{hostvars[item].inventory_hostname}}"
-      validate_certs: "no"
     loop: "{{ groups['webservers'] }}"
 ```
 <!-- {% endraw %} -->
@@ -74,6 +75,7 @@ Next, add the first `task`. This task will use the `bigip_node` module configure
 - `name: CREATE NODES` is a user defined description that will display in the terminal output.
 - `bigip_node:` tells the task which module to use.  Everything except `loop` is a module parameter defined on the module documentation page.
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The`password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with

--- a/exercises/ansible_f5/1.2-add-node/bigip-node.yml
+++ b/exercises/ansible_f5/1.2-add-node/bigip-node.yml
@@ -8,11 +8,12 @@
 
   - name: CREATE NODES
     bigip_node:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       host: "{{hostvars[item].ansible_host}}"
       name: "{{hostvars[item].inventory_hostname}}"
-      validate_certs: "no"
     loop: "{{ groups['webservers'] }}"

--- a/exercises/ansible_f5/1.3-add-pool/README.md
+++ b/exercises/ansible_f5/1.3-add-pool/README.md
@@ -59,15 +59,16 @@ Next, add the first `task`. This task will use the `bigip_pool` module configure
 
   - name: CREATE POOL
     bigip_pool:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "http_pool"
       lb_method: "round-robin"
       monitors: "/Common/http"
       monitor_type: "and_list"
-      validate_certs: "no"
 ```
 
 <!-- {% endraw %} -->
@@ -75,6 +76,7 @@ Next, add the first `task`. This task will use the `bigip_pool` module configure
 - `name: CREATE POOL` is a user defined description that will display in the terminal output.
 - `bigip_pool:` tells the task which module to use.
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The`password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with

--- a/exercises/ansible_f5/1.3-add-pool/bigip-pool.yml
+++ b/exercises/ansible_f5/1.3-add-pool/bigip-pool.yml
@@ -8,12 +8,13 @@
 
   - name: CREATE POOL
     bigip_pool:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "http_pool"
       lb_method: "round-robin"
       monitors: "/Common/http"
       monitor_type: "and_list"
-      validate_certs: "no"

--- a/exercises/ansible_f5/1.4-add-pool-members/README.md
+++ b/exercises/ansible_f5/1.4-add-pool-members/README.md
@@ -57,16 +57,17 @@ Next, add the first `task`. This task will use the `bigip_pool_member` module co
 
   - name: ADD POOL MEMBERS
     bigip_pool_member:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       state: "present"
       name: "{{hostvars[item].inventory_hostname}}"
       host: "{{hostvars[item].ansible_host}}"
       port: "80"
       pool: "http_pool"
-      validate_certs: "no"
     loop: "{{ groups['webservers'] }}"
 ```
 {% endraw %}
@@ -78,6 +79,7 @@ Explanation of each line within the task:
 
 Next we have module parameters
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The`password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with

--- a/exercises/ansible_f5/1.4-add-pool-members/bigip-pool-members.yml
+++ b/exercises/ansible_f5/1.4-add-pool-members/bigip-pool-members.yml
@@ -8,14 +8,15 @@
 
   - name: ADD POOL MEMBERS
     bigip_pool_member:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       state: "present"
       name: "{{hostvars[item].inventory_hostname}}"
       host: "{{hostvars[item].ansible_host}}"
       port: "80"
       pool: "http_pool"
-      validate_certs: "no"
     loop: "{{ groups['webservers'] }}"

--- a/exercises/ansible_f5/1.5-add-virtual-server/README.md
+++ b/exercises/ansible_f5/1.5-add-virtual-server/README.md
@@ -61,10 +61,12 @@ Next, add the `task`. This task will use the `bigip-virtual-server` to configure
 
   - name: ADD VIRTUAL SERVER
     bigip_virtual_server:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "vip"
       destination: "{{private_ip}}"
       port: "443"
@@ -72,7 +74,6 @@ Next, add the `task`. This task will use the `bigip-virtual-server` to configure
       all_profiles: ['http','clientssl','oneconnect']
       pool: "http_pool"
       snat: "Automap"
-      validate_certs: "no"
 ```
 
 <!-- {% endraw %} -->
@@ -82,6 +83,7 @@ Next, add the `task`. This task will use the `bigip-virtual-server` to configure
 - `name: ADD VIRTUAL SERVER` is a user defined description that will display in the terminal output.
 - `bigip_virtual_server:` tells the task which module to use.
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The`password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with

--- a/exercises/ansible_f5/1.5-add-virtual-server/bigip-virtual-server.yml
+++ b/exercises/ansible_f5/1.5-add-virtual-server/bigip-virtual-server.yml
@@ -7,10 +7,12 @@
 
   - name: ADD VIRTUAL SERVER
     bigip_virtual_server:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "vip"
       destination: "{{private_ip}}"
       port: "443"
@@ -18,4 +20,3 @@
       all_profiles: ['http','clientssl','oneconnect']
       pool: "http_pool"
       snat: "Automap"
-      validate_certs: "no"

--- a/exercises/ansible_f5/1.6-add-irules/README.md
+++ b/exercises/ansible_f5/1.6-add-irules/README.md
@@ -87,15 +87,16 @@ Next, add the `task`. This task will use the `bigip-irule` to add irules to the 
 
   - name: ADD iRules
     bigip_irule:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       module: "ltm"
       name: "{{item}}"
       content: "{{lookup('file','{{item}}')}}"
-    loop: "{{irules}}"
+    with_items: "{{irules}}"
 ```
 {% endraw %}
 
@@ -106,6 +107,7 @@ Next, add the `task`. This task will use the `bigip-irule` to add irules to the 
 - `name: ADD iRules` is a user defined description that will display in the terminal output.
 - `bigip_irule:` tells the task which module to use.
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The `password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with
@@ -134,23 +136,25 @@ Next, add the `task`. This task will use the `bigip_virtual_server` to add attac
 
   - name: ADD iRules
     bigip_irule:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       module: "ltm"
       name: "{{item}}"
       content: "{{lookup('file','{{item}}')}}"
-    loop: "{{irules}}"
-
-  - name: ATTACH iRules TO EXISTING VIRTUAL SERVER
+    with_items: "{{irules}}"
+    
+  - name: ATTACH iRules TO VIRTUAL SERVER
     bigip_virtual_server:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "vip"
       irules: "{{irules}}"
 ```

--- a/exercises/ansible_f5/1.6-add-irules/bigip-irule.yml
+++ b/exercises/ansible_f5/1.6-add-irules/bigip-irule.yml
@@ -10,11 +10,12 @@
 
   - name: ADD iRules
     bigip_irule:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       module: "ltm"
       name: "{{item}}"
       content: "{{lookup('file','{{item}}')}}"
@@ -22,10 +23,11 @@
     
   - name: ATTACH iRules TO VIRTUAL SERVER
     bigip_virtual_server:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       name: "vip"
       irules: "{{irules}}"

--- a/exercises/ansible_f5/1.7-save-running-config/README.md
+++ b/exercises/ansible_f5/1.7-save-running-config/README.md
@@ -60,11 +60,12 @@ Next, add the `task`. This task will use the `bigip-config` to save the running 
 
   - name: SAVE RUNNING CONFIG ON BIG-IP
     bigip_config:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       save: yes
 ```
 {% endraw %}
@@ -75,6 +76,7 @@ Next, add the `task`. This task will use the `bigip-config` to save the running 
 - `name: SAVE RUNNING CONFIG ON BIG-IP` is a user defined description that will display in the terminal output.
 - `bigip_config:` tells the task which module to use.
 - The `server: "{{private_ip}}"` parameter tells the module to connect to the F5 BIG-IP IP address, which is stored as a variable `private_ip` in inventory
+- The `provider:` parameter is a group of connection details for the BIG-IP.
 - The `user: "{{ansible_user}}"` parameter tells the module the username to login to the F5 BIG-IP device with
 - The`password: "{{ansible_ssh_pass}}"` parameter tells the module the password to login to the F5 BIG-IP device with
 - The `server_port: 8443` parameter tells the module the port to connect to the F5 BIG-IP device with

--- a/exercises/ansible_f5/1.7-save-running-config/bigip-config.yml
+++ b/exercises/ansible_f5/1.7-save-running-config/bigip-config.yml
@@ -7,9 +7,10 @@
 
   - name: SAVE RUNNING CONFIG ON BIG-IP
     bigip_config:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: 8443
+        validate_certs: no
       save: yes

--- a/provisioner/roles/f5_setup/tasks/main.yml
+++ b/provisioner/roles/f5_setup/tasks/main.yml
@@ -1,13 +1,3 @@
-#   not working right now, possible bug or mis-use of module
-# - name: Wait for BIG-IP to boot up completely
-#   bigip_wait:
-#     provider:
-#       ssh_keyfile: "{{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
-#       transport: cli
-#       user: admin
-#       validate_certs: false
-#       server: "{{ ansible_host }}"
-
 - name: Wait for BIG-IP to boot up completely
   wait_for:
     host: "{{ ansible_host }}"
@@ -23,13 +13,24 @@
       server: "{{ ansible_host }}"
     commands: "modify auth user admin password {{admin_password}}"
 
-# The bigip_iapplx_package requires rpm installed, on macOS use brew rather than pip or it won't work
+- name: Wait for API to be Ready
+  bigip_wait:
+    timeout: 300
+    provider:
+      validate_certs: "no"
+      user: admin
+      password: "{{admin_password}}"
+      server_port: 8443
+      server: "{{ ansible_host }}"
+  delegate_to: localhost
+
+# The bigip_lx_package requires rpm installed, on macOS use brew rather than pip or it won't work
 - name: Install AS3
-  bigip_iapplx_package:
+  bigip_lx_package:
     package: "{{playbook_dir}}/roles/f5_setup/files/f5-appsvcs-3.4.0-2.noarch.rpm"
     provider:
       validate_certs: "no"
       user: admin
       password: "{{admin_password}}"
-      server_port: "8443"
+      server_port: 8443
       server: "{{ ansible_host }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added provider connection to all of the 1.x exercises.
Added bigip_wait to the provisioner
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Using connection details directly outside of provider is being deprecated. This update is adding each task in the 1.x exercises to use provider.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
