### PR TITLE
conditionally install Ansible 2.9 for Security control host

### DIFF
--- a/provisioner/roles/control_node/tasks/security.yml
+++ b/provisioner/roles/control_node/tasks/security.yml
@@ -50,3 +50,17 @@
     owner: "{{ username }}"
     group: "{{ username }}"
   when: username in inventory_hostname
+
+# FIXME: REMOVE THIS ENTIRE BLOCK ONCE ANSIBLE ENGINE 2.9 GOES GA
+- name: Install Ansible 2.9 pre-release (if necessary)
+  block:
+    - name: Get package facts
+      package_facts:
+        manager: rpm
+
+    - name: Install Ansible 2.9 pre-release
+      yum:
+        state: latest
+        name: 'https://releases.ansible.com/ansible/rpm/nightly/devel/epel-7-x86_64/ansible-2.9.0-1.201908210200git.2bbbc5fafc.el7.ans.noarch.rpm'
+      when:
+        - ansible_facts['packages']['ansible'][0]['version'] < '2.9.0'


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
conditionally install Ansible 2.9 for Security control host 

The Ansible Security Workshop depends on Ansible 2.9.x and newer, we need to conditionally install the dev/nightly build until it goes GA
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
