### PR TITLE
set selinux permissive because current policy breaks snort

### DIFF
--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -12,16 +12,30 @@
     ids_install_snort_user: root
     ids_install_snort_group: root
   tasks:
-    - block:
-      - name: setup epel for snort ecosystem rule lifecycling
-        include_role:
-          name: "geerlingguy.repo-epel"
-      - name: import ids_install role
-        include_role:
-          name: "ansible_security.ids_install"
-      - name: import ids_config role
-        include_role:
-          name: "ansible_security.ids_config"
+    - name: Install Pre Reqs for IDS
+      block:
+        - name: package pre-reqs are installed
+          yum:
+            state: present
+            name:
+              - libselinux-python
+
+        - name: set selinux permissve because of policy issue that breaks snort
+          selinux:
+            policy: targeted
+            state: permissive
+
+    - name: Install IDS
+      block:
+        - name: setup epel for snort ecosystem rule lifecycling
+          include_role:
+            name: "geerlingguy.repo-epel"
+        - name: import ids_install role
+          include_role:
+            name: "ansible_security.ids_install"
+        - name: import ids_config role
+          include_role:
+            name: "ansible_security.ids_config"
 
 - name: SETUP CHECKPOINT ENVIRONMENT
   hosts: localhost


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
set selinux permissive because current policy breaks snort
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
