### PR TITLE
Add idstools to snort

### DIFF
--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -15,10 +15,11 @@
     - name: Install Pre Reqs for IDS
       block:
         - name: package pre-reqs are installed
-          yum:
+          package:
             state: present
             name:
               - libselinux-python
+              - python2-idstools
 
         - name: set selinux permissve because of policy issue that breaks snort
           selinux:


### PR DESCRIPTION
##### SUMMARY

The ids_rule role cannot work without the idstools package.
Also, changed module to "package" instead of yum for possible future migrations.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner
