### PR TITLE
Add state check when identifying corresponding CP mgmt and ngfw

### DIFF
--- a/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
+++ b/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
@@ -6,6 +6,7 @@
       "tag:short_name": checkpoint_mgmt
       "tag:Student": "student{{ student_number }}"
       "tag:Workshop": "{{ ec2_name_prefix }}"
+      "instance-state-name": running
   register: mgmt_inst
 
 - name: get gw instances
@@ -15,6 +16,7 @@
       "tag:short_name": checkpoint_gw
       "tag:Student": "student{{ student_number }}"
       "tag:Workshop": "{{ ec2_name_prefix }}"
+      "instance-state-name": running
   register: gw_inst
 
 - name: login, get SID


### PR DESCRIPTION
##### SUMMARY

We need to add the NGFW to the MGMT server. To identify the two machines which belong to the same student we use ec2_facts. However, until now there could be a race condition if a workshop was deployed, tore down and re-deployed with the same name fast enough. In that case for each student there could be two NGFW or two MGMT, each time one without a public IP. That might led to error messages.

This commit adds a state filter to ensure we only find running machines.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner