### PR TITLE
narrow ec2 instance filter to avoid globbing

### DIFF
--- a/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
+++ b/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
@@ -3,9 +3,7 @@
   ec2_instance_facts:
     region: "{{ ec2_region }}"
     filters:
-      "tag:short_name": checkpoint_mgmt
-      "tag:Student": "student{{ student_number }}"
-      "tag:Workshop": "{{ ec2_name_prefix }}"
+      "tag:Name": "{{ ec2_name_prefix }}-student{{ student_number }}-checkpoint_mgmt"
       "instance-state-name": running
   register: mgmt_inst
 
@@ -13,9 +11,7 @@
   ec2_instance_facts:
     region: "{{ ec2_region }}"
     filters:
-      "tag:short_name": checkpoint_gw
-      "tag:Student": "student{{ student_number }}"
-      "tag:Workshop": "{{ ec2_name_prefix }}"
+      "tag:Name": "{{ ec2_name_prefix }}-student{{ student_number }}-checkpoint_gw"
       "instance-state-name": running
   register: gw_inst
 


### PR DESCRIPTION
##### SUMMARY

Current filter setup fails if a workshop name is reused as part of another workshop name.
This new filter avoids such filter globbing.
The same solution is used in other parts of the provisioner already.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner