### PR TITLE
Fix 503 error during CP deployment

### DIFF
--- a/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
+++ b/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
@@ -27,7 +27,7 @@
   register: login_data
   until: (login_data.status == 200) and (login_data.json is defined)
   retries: 60
-  delay: 5
+  delay: 15
 
 - name: Add NGFW to MGMT
   uri:

--- a/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
+++ b/provisioner/roles/cp_setup/tasks/add_gw_to_mgmt.yml
@@ -25,6 +25,9 @@
     body_format: json
     validate_certs: no
   register: login_data
+  until: (login_data.status == 200) and (login_data.json is defined)
+  retries: 60
+  delay: 5
 
 - name: Add NGFW to MGMT
   uri:

--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -14,6 +14,9 @@
   tasks:
     - name: Install Pre Reqs for IDS
       block:
+        - name: setup epel for snort ecosystem rule lifecycling
+          include_role:
+            name: "geerlingguy.repo-epel"
         - name: package pre-reqs are installed
           package:
             state: present
@@ -28,15 +31,17 @@
 
     - name: Install IDS
       block:
-        - name: setup epel for snort ecosystem rule lifecycling
-          include_role:
-            name: "geerlingguy.repo-epel"
         - name: import ids_install role
           include_role:
             name: "ansible_security.ids_install"
         - name: import ids_config role
           include_role:
             name: "ansible_security.ids_config"
+
+- name: SETUP WINDOWS WORKSTATION
+  hosts: windows
+  roles:
+    - role: windows_ws_setup
 
 - name: SETUP CHECKPOINT ENVIRONMENT
   hosts: localhost
@@ -45,8 +50,3 @@
   gather_facts: no
   roles:
     - role: cp_setup
-
-- name: SETUP WINDOWS WORKSTATION
-  hosts: windows
-  roles:
-    - role: windows_ws_setup


### PR DESCRIPTION
##### SUMMARY

Ensuring that the Check Point MGMT-NGFW auto registration waits until the server is spun up properly. Otherwise, in certain race conditions that task is executed before the machine is ready to accept connections.

Note: for some reason deployment of CP sometimes takes very long. To not depend on this I reordered the deployment tasks: all Windows related tasks will be executed before the Check Point auto-merge, so that hopefully the machine is mostly ready by then.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner
