### PR TITLE
Emergency: Pin Windows image date

### DIFF
--- a/provisioner/roles/manage_ec2_instances/defaults/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main.yml
@@ -60,7 +60,7 @@ ec2_info:
     username: admin
   windows_ws:
     owners: 679593333241
-    filter: 'Windows_Server-2016-English-Full-Base*'
+    filter: 'Windows_Server-2016-English-Full-Base-2019.08.16'
     size: m5.xlarge
     ami: "{{ windows_ws_ami| default(omit) }}"
     username: Administrator


### PR DESCRIPTION
##### SUMMARY

AWS just updated their Windows image and added group policies which render our winrm config script unusable.
This change pins the windows image to a version prior to the change.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner

##### ADDITIONAL INFORMATION

This is an emergency patch - no security workshop can be deployed right now.