### PR TITLE
Fix Ansible RHEL Workshop Exercise 1.6 template error

### DIFF
--- a/exercises/ansible_rhel/1.6-templates/README.ja.md
+++ b/exercises/ansible_rhel/1.6-templates/README.ja.md
@@ -77,12 +77,14 @@ Ansibleが変数をシステムから収取したファクト情報で変数を�
 
   - `motd-facts.j2` を以下の通り更新します
 
-```bash
+<!-- {% raw %} -->
+```html+jinja
 Welcome to {{ ansible_hostname }}.
 {{ ansible_distribution }} {{ ansible_distribution_version}}
 deployed on {{ ansible_architecture }} architecture
 running kernel {{ ansible_kernel }}.
 ```
+<!-- {% endraw %} -->
 
   - playbook を実行します
   - node1 にログインし、表示をチェックします

--- a/exercises/ansible_rhel/1.6-templates/README.md
+++ b/exercises/ansible_rhel/1.6-templates/README.md
@@ -80,12 +80,14 @@ Add a line to the template to list the current kernel of the managed node.
 
   - Modify the template `motd-facts.j2`:
 
-```bash
+<!-- {% raw %} -->
+```html+jinja
 Welcome to {{ ansible_hostname }}.
 {{ ansible_distribution }} {{ ansible_distribution_version}}
 deployed on {{ ansible_architecture }} architecture
 running kernel {{ ansible_kernel }}.
 ```
+<!-- {% endraw %} -->
 
   - Run the playbook.
   - Verify the new message via SSH login to `node1`.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the RHEL workshop 1.6 bonus solution in order to display the Jinja2 template correctly.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Visit https://ansible.github.io/workshops/exercises/ansible_rhel/1.6-templates/ and compare the first template code block with the bonus challenge solution code block. Due to the missing tags, the bonus solution does not display the Ansible Variables as expected.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
