### PR TITLE
Update main.yml to include cockpit installation

### DIFF
--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -17,10 +17,24 @@
       - python-pip
       - ansible
       - gcc
+      - cockpit
       # - https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.7.0-1.el7.ans.noarch.rpm
     state: present
   retries: 10
   delay: 5
+
+- name: cockpit (RHEL web console for web terminal) is started and enabled
+  service:
+    name: cockpit.socket
+    state: started
+    enabled: yes
+
+- name: open port for cockpit (RHEL web console) in firewall
+  firewalld:
+    port: 9090/tcp
+    immediate: true
+    permanent: true
+    state: enabled
 
 - name: Install ansible.cfg and vimrc in home directory
   template:

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -29,13 +29,6 @@
     state: started
     enabled: yes
 
-- name: open port for cockpit (RHEL web console) in firewall
-  firewalld:
-    port: 9090/tcp
-    immediate: true
-    permanent: true
-    state: enabled
-
 - name: Install ansible.cfg and vimrc in home directory
   template:
     src: ansible.cfg.j2


### PR DESCRIPTION
Added package installation and firewall changes to allow cockpit (RHEL Web Console) to run on 9090/tcp.  This will allow those workshop students without an ssh client to get to a terminal session on the control node.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs
- decks
- provisioner
- demos

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
