### PR TITLE
Fixed Inconsistent Naming

### DIFF
--- a/exercises/ansible_rhel/2.7-wrap/README.md
+++ b/exercises/ansible_rhel/2.7-wrap/README.md
@@ -14,7 +14,7 @@ Your operations team and your application development team like what they see in
 
 - As the webservers can be used for development purposes or in production, there has to be a way to flag them accordingly as "stage dev" or "stage prod".
 
-    - Currently `host1` is used as a development system and `host2` is in production.
+    - Currently `node1` is used as a development system and `node2` is in production.
 
 - Of course the content of the world famous application "index.html" will be different between dev and prod stages.
 


### PR DESCRIPTION
Changed 'host1' and 'host2' to 'node1' and 'node2' since 'host1' and 'host2' are not used anywhere else in the document.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
-
##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- decks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
