### PR TITLE
Fix workshop links, technical is replaced by rhel deck

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -4,7 +4,7 @@ The `github.com/ansible/workshops` contains a provisioner `provision_lab.yml`, w
 
 | Workshop   | Deck  | Exercises  | Workshop Type Var   |
 |---|---|---|---|
-| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://ansible.github.io/workshops/decks/ansible_technical.pdf)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
+| Ansible Red Hat Enterprise Linux Workshop  | [Deck](https://ansible.github.io/workshops/decks/ansible_rhel.pdf)  | [Exercises](../exercises/ansible_rhel) | `workshop_type: rhel`  |
 | Ansible Network Automation Workshop  | [Deck](https://ansible.github.io/workshops/decks/ansible_network.pdf) | [Exercises](../exercises/ansible_network)  | `workshop_type: networking`  |
 | Ansible F5 Workshop | [Deck](https://ansible.github.io/workshops/decks/ansible_f5.pdf) | [Exercises](../exercises/ansible_f5)   | `workshop_type: f5`   |
 

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -271,7 +271,7 @@ $("document").ready(function(){
                 <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/exercises/ansible_rhel/">Ansible RHEL Exercises</a>
             </div>
             <div class="col-sm-4">
-              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/decks/ansible_technical.pdf">Ansible Technical Deck</a>
+              <a class="btn btn-secondary btn-block" href="https://ansible.github.io/workshops/decks/ansible_rhel.pdf">Ansible Technical Deck</a>
             </div>
         </div>
         {% elif workshop_type == "security" %}


### PR DESCRIPTION
##### SUMMARY

Fix workshop links: technical deck was replaced by rhel deck and removed afterwards, but I missed two links.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- decks