### PR TITLE
resync windows tasks, the registry isn't happy with async things

### DIFF
--- a/provisioner/roles/windows_ws_setup/tasks/chrome.yml
+++ b/provisioner/roles/windows_ws_setup/tasks/chrome.yml
@@ -32,9 +32,6 @@
     name: DefaultBrowserSettingEnabled
     data: 0
     type: dword
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: dont_ask_default_browser_async
 
 - name: Disable Chrome Welcome Screen
   win_regedit:
@@ -45,9 +42,6 @@
   with_items:
     - PromotionalTabsEnabled
     - WelcomePageOnOSUpgradeEnabled
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: disable_chrome_welcome_screen_async
 
 - name: Disable Chrome Syncing
   win_regedit:
@@ -55,17 +49,4 @@
     name: SyncDisabled
     data: 1
     type: dword
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: disable_chrome_sync_async
 
-- name: Wait for Windows async tasks (chrome)
-  async_status:
-    jid: "{{ item['ansible_job_id'] }}"
-  register: wait_for_async_tasks
-  until: wait_for_async_tasks.finished
-  retries: "{{ windows_async_timeout }}"
-  loop: >
-    {{ disable_chrome_welcome_screen_async['results'] }}
-    + [{{ disable_chrome_sync_async }}]
-    + [{{ dont_ask_default_browser_async }}]

--- a/provisioner/roles/windows_ws_setup/tasks/myrtille.yml
+++ b/provisioner/roles/windows_ws_setup/tasks/myrtille.yml
@@ -51,9 +51,6 @@
   with_items:
     - SecurityLayer
     - UserAuthentication
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: disable_ntlm_async
 
 - name: Create RDP Application
   win_iis_webapplication:
@@ -62,13 +59,3 @@
     application_pool: MyrtilleAppPool
     physical_path: C:\Program Files (x86)\Myrtille\
     state: present
-
-- name: Wait for Windows async tasks (myrtille)
-  async_status:
-    jid: "{{ item['ansible_job_id'] }}"
-  register: wait_for_async_tasks
-  until: wait_for_async_tasks.finished
-  retries: "{{ windows_async_timeout }}"
-  loop: "{{ disable_ntlm_async['results'] }}"
-
-

--- a/provisioner/roles/windows_ws_setup/tasks/server_mgmt.yml
+++ b/provisioner/roles/windows_ws_setup/tasks/server_mgmt.yml
@@ -6,35 +6,15 @@
     data: 1
     type: dword
 
-- name: Remove EC2 Feedback Icon async
+- name: Remove EC2 Feedback Icon
   win_file:
     path: C:\Users\Administrator\Desktop\EC2 Feedback.website
     state: absent
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: remove_ec2_feedback_icon_async
 
-- name: Remove EC2 Website Icon async
+- name: Remove EC2 Website Icon
   win_file:
     path: C:\Users\Administrator\Desktop\EC2 Microsoft Windows Guide.website
     state: absent
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: remove_ec2_website_icon_async
 
-- name: Remove network notice async
+- name: Remove network notice
   win_command: netsh advfirewall firewall set rule group="Network Discovery" new enable=No
-  async: "{{ windows_async_timeout }}"
-  poll: 0
-  register: remove_network_notice_async
-
-- name: Wait for Windows async tasks (server_mgmt)
-  async_status:
-    jid: "{{ item['ansible_job_id'] }}"
-  register: wait_for_async_tasks
-  until: wait_for_async_tasks.finished
-  retries: "{{ windows_async_timeout }}"
-  loop:
-    - "{{ remove_ec2_website_icon_async }}"
-    - "{{ remove_ec2_feedback_icon_async }}"
-    - "{{ remove_network_notice_async }}"

--- a/provisioner/roles/windows_ws_setup/tasks/smartconsole.yml
+++ b/provisioner/roles/windows_ws_setup/tasks/smartconsole.yml
@@ -1,45 +1,19 @@
 ---
 - block:
-  - name: Download Microsoft Visual C++ Redistributable Packages needed for SmartConsole async
+  - name: Download Microsoft Visual C++ Redistributable Packages needed for SmartConsole
     win_chocolatey:
       name:
         - vcredist2010
         - vcredist2012
       state: present
-    async: "{{ windows_async_timeout }}"
-    poll: 0
-    register: download_visual_cpp_async
 
-  - name: Wait for Download Microsoft Visual C++ async
-    async_status:
-      jid: "{{ download_visual_cpp_async.ansible_job_id }}"
-    register: job_result
-    until: job_result.finished
-    retries: 30
-
-  - name: Ensure the required NuGet package provider version is installed async
+  - name: Ensure the required NuGet package provider version is installed
     win_shell: Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force
-    async: "{{ windows_async_timeout }}"
-    poll: 0
-    register: ensure_nuget_async
 
-  - name: Install Pscx needed for unzip step later async
+  - name: Install Pscx needed for unzip step later
     win_psmodule:
       name: pscx
       allow_clobber: true
-    async: "{{ windows_async_timeout }}"
-    poll: 0
-    register: install_pscx_async
-
-  - name: Wait for Windows async tasks (smartconsole)
-    async_status:
-      jid: "{{ item['ansible_job_id'] }}"
-    register: wait_for_async_tasks
-    until: wait_for_async_tasks.finished
-    retries: "{{ windows_async_timeout }}"
-    loop:
-      - "{{ ensure_nuget_async }}"
-      - "{{ install_pscx_async }}"
 
   - name: Check if SmartConsole is downloaded
     win_stat:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix async error that were being ignored by removing async all together. It turns out Windows and async tasks don't get along in general because there are sometimes race conditions on things that modify the registry. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

