### PR TITLE
Cut the waiting time for login try to half

### DIFF
--- a/provisioner/roles/cp_setup/tasks/main.yml
+++ b/provisioner/roles/cp_setup/tasks/main.yml
@@ -10,7 +10,7 @@
     validate_certs: no
   register: login_data
   until: (login_data.status == 200) and (login_data.json is defined)
-  retries: 60
+  retries: 30
   delay: 10
 
 - name: Add NGFW to MGMT


### PR DESCRIPTION
##### SUMMARY

We should not wait too long for log in tests, otherwise we run into timeouts in the next step.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner