### PR TITLE
dynamically set async timeouts and retries based on student count

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/instances_security.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_security.yml
@@ -1,8 +1,8 @@
 - import_tasks: ami_find_security.yml
 
 - set_fact:
-    async_timeout_seconds: 300
-    async_wait_for_retries: 10
+    async_timeout_seconds: "{{ student_total * 60 }}"
+    async_wait_for_retries: "{{ student_total * 10 }}"
 
 - name: Create EC2 Block - SECURITY MODE
   block:

--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -16,6 +16,9 @@
 - name: Install Pre Reqs on attacker
   hosts: attack
   become: yes
+  vars:
+    async_timeout_seconds: "{{ student_total * 60 }}"
+    async_wait_for_retries: "{{ student_total * 10}}"
   tasks:
     - name: setup epel on attacker
       include_role:
@@ -26,7 +29,7 @@
         state: present
         name:
           - daemonize
-      async: 1000
+      async: "{{ async_timeout_seconds }}"
       poll: 0
       register: yum_async
 
@@ -35,7 +38,7 @@
         jid: "{{ yum_async.ansible_job_id }}"
       register: job_result
       until: job_result.finished
-      retries: 30
+      retries: "{{ async_wait_for_retries }}"
 
 
 - name: include splunk playbook
@@ -56,6 +59,8 @@
     ids_install_snort_group: root
     ids_normalize_logs: false
     ids_install_snort_interface: eth1
+    async_timeout_seconds: "{{ student_total * 60 }}"
+    async_wait_for_retries: "{{ student_total * 10 }}"
   tasks:
     - name: Set fact vars for ids based SIEM type
       block:
@@ -81,7 +86,7 @@
             name:
               - libselinux-python
               - python2-idstools
-          async: 1000
+          async: "{{ async_timeout_seconds }}"
           poll: 0
           register: yum_async
 
@@ -90,7 +95,7 @@
             jid: "{{ yum_async.ansible_job_id }}"
           register: job_result
           until: job_result.finished
-          retries: 30
+          retries: "{{ async_wait_for_retries }}"
 
         - name: set selinux permissve because of policy issue that breaks snort
           selinux:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously the security workshop async timeouts and retries were set statically, this will eventually timeout when you hit a certain `student_total` threshold.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

