### PR TITLE
[WIP] RHUI: Ensure latest is installed and update repo names

### DIFF
--- a/provisioner/roles/aws_dns/tasks/tower.yml
+++ b/provisioner/roles/aws_dns/tasks/tower.yml
@@ -10,7 +10,6 @@
 - name: INSTALL CERTBOT
   yum:
     name: certbot
-    enablerepo: "rhui-REGION-rhel-server-extras,rhui-REGION-rhel-server-optional"
 
 #https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
 - name: TURN OFF TOWER

--- a/provisioner/roles/common/tasks/main.yml
+++ b/provisioner/roles/common/tasks/main.yml
@@ -16,6 +16,39 @@
 - hostname:
     name: "{{short_name}}"
 
+- name: Update rh-amazon-rhui-client to latest
+  yum:
+    name: rh-amazon-rhui-client
+    state: latest
+
+- command: rpm -q rh-amazon-rhui-client
+  register: rhui_version_out
+
+- set_fact:
+    rhui_version: "{{ rhui_version_out.stdout }}"
+
+- set_fact:
+    redhat_aws_rhui_repos:
+      - rhui-REGION-rhel-server-extras
+      - rhui-REGION-rhel-server-rhscl
+      - rhui-REGION-rhel-server-rhscl
+  when: rhui_version is match('rh-amazon-rhui-client-2')
+
+- set_fact:
+    redhat_aws_rhui_repos:
+      - rhel-7-server-rhui-extras-rpms
+      - rhel-7-server-rhui-optional-rpms
+      - rhel-server-rhui-rhscl-7-rpms
+  when: rhui_version is match('rh-amazon-rhui-client-3')
+
+- name: enable rhui repositories
+  ini_file:
+    dest: '/etc/yum.repos.d/redhat-rhui.repo'
+    section: '{{ item  }}'
+    option: enabled
+    value: 1
+  with_items: '{{ redhat_aws_rhui_repos }}'
+
 - meta: flush_handlers
   tags:
     - common

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -18,8 +18,15 @@
     src: tower_install.j2
     dest: /tmp/tower_install/inventory
 
+- copy:
+    dest: /tmp/tower_install/extras-vars.yml
+    content: |
+      redhat_aws_rhui_repos: {{ redhat_aws_rhui_repos | to_yaml }}
+
 - name: run the Ansible Tower installer
-  shell: ./setup.sh chdir=/tmp/tower_install
+  shell: ./setup.sh -e @extras-vars.yml
+  args:
+    chdir: /tmp/tower_install
   async: 900
   poll: 10
 

--- a/provisioner/roles/splunk_enterprise/tasks/main.yml
+++ b/provisioner/roles/splunk_enterprise/tasks/main.yml
@@ -103,7 +103,6 @@
 - name: INSTALL CERTBOT
   yum:
     name: certbot
-    enablerepo: "rhui-REGION-rhel-server-extras,rhui-REGION-rhel-server-optional"
 
 #If this fails check out status of certbot: https://letsencrypt.status.io/
 - name: ISSUE CERT


### PR DESCRIPTION
RHUI has starting rolling a major upgrade from rhui2 to rhui3 across all
amazon regions. This implies a repo name change.

Regions that are still deploying with rhui2 infra are fine for now, but
`us-east-1` for example has rolled out to rhui3 making the repo name
inaccurate now.

Thjs commit addresses this issue.