### PR TITLE
Make sure to always pick the right eni when source-dest check is changed

### DIFF
--- a/provisioner/roles/cp_setup/tasks/main.yml
+++ b/provisioner/roles/cp_setup/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: disable source_dest_checking on AWS interface
   ec2_eni:
     region: "{{ ec2_region }}"
-    eni_id: "{{ gw_inst['instances'][0]['network_interfaces'][1]['network_interface_id'] }}"
+    eni_id: "{{ gw_inst['instances'][0]['network_interfaces'][0]['network_interface_id'] if gw_inst['instances'][0]['network_interfaces'][0]['attachment']['device_index'] == 1 else gw_inst['instances'][0]['network_interfaces'][1]['network_interface_id'] }}"
     source_dest_check: no
     state: present
   delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY

Make sure to always pick the right eni when source-dest check is changed

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner
