### PR TITLE
updated RHEL 7.7 search filters

### DIFF
--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -66,7 +66,7 @@
     url: https://localhost/api/v2/settings/system/
     method: PATCH
     user: admin
-    password: "ansible"
+    password: "{{admin_password}}"
     validate_certs: False
     force_basic_auth: yes
     body_format: json

--- a/provisioner/roles/manage_ec2_instances/defaults/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main.yml
@@ -71,7 +71,7 @@ ec2_info:
     os_type: linux
     disk_space: 20
     architecture: x86_64
-    filter: 'RHEL-7.6_HVM-20190515-x86_64-0-Access2-GP2'
+    filter: 'RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2'
     username: ec2-user
   rhel7:
     owners: 309956199498
@@ -79,7 +79,7 @@ ec2_info:
     os_type: linux
     disk_space: 10
     architecture: x86_64
-    filter: 'RHEL-7.6_HVM-20190515-x86_64-0-Access2-GP2'
+    filter: 'RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2'
     username: ec2-user
     python_interpreter: '/usr/bin/python'
   f5node:
@@ -96,7 +96,7 @@ ec2_info:
     os_type: linux
     disk_space: 200
     architecture: x86_64
-    filter: 'RHEL-7.6_HVM-20190515-x86_64-0-Access2-GP2'
+    filter: 'RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2'
     username: ec2-user
     python_interpreter: '/usr/bin/python'
   netapp:


### PR DESCRIPTION
##### SUMMARY
The AMI search filters didn't work for me. It looks like the filter string has to be "RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2" - at least that's working for me, and the previous filter did not.

If there is a specific reason to stick with RHEL 7.6, the filter is: RHEL-7.6_HVM_GA-20190128-x86_64-0-Hourly2-GP2

The original filter string RHEL-7.6_HVM-20190515-x86_64-0-Access2-GP2 did not return any AMI ID's for me.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
