### PR TITLE
use password variable instead of hard coded value

### DIFF
--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -66,7 +66,7 @@
     url: https://localhost/api/v2/settings/system/
     method: PATCH
     user: admin
-    password: "ansible"
+    password: "{{admin_password}}"
     validate_certs: False
     force_basic_auth: yes
     body_format: json


### PR DESCRIPTION
##### SUMMARY
The ansible tower password was still hard coded and the variable was not used. This PR will use the variable admin_password instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
