### PR TITLE
Introduce support for Coder (vscode in browser)

### DIFF
--- a/provisioner/roles/control_node/files/code-server.service.j2
+++ b/provisioner/roles/control_node/files/code-server.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Code Server IDE
+After=network.target
+
+[Service]
+Type=simple
+User={{username}}
+WorkingDirectory=/home/{{username}}
+Restart=on-failure
+RestartSec=10
+
+ExecStart=/opt/code-server --auth none /home/{{username}}
+
+StandardOutput=file:/var/log/code-server-output.log
+StandardError=file:/var/log/code-server-error.log
+
+[Install]
+WantedBy=multi-user.target

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -36,6 +36,59 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
+- name: Get latest release of Coder binary
+  uri:
+    url: https://api.github.com/repos/cdr/code-server/releases/latest
+  register: github_result
+
+- name: Save url for extraction of Coder binary
+  set_fact:
+    download_url: "{{item.browser_download_url}}"
+    version_name: "{{item.name.split('.tar')[0]}}"
+  when: "'linux' in item.browser_download_url"
+  loop: "{{github_result.json.assets}}"
+  loop_control: 
+    label: "{{ item.browser_download_url }}"
+
+- name: Extract file
+  unarchive:
+    src: "{{download_url}}"
+    dest: "/home/{{username}}"
+    remote_src: yes
+  register: output
+    
+- name: Install ansible vscode extension
+  command: "/home/{{username}}/{{ version_name }}/code-server --auth none --install-extension vscoss.vscode-ansible"
+  register: result
+
+- name: Move binary to /opt
+  copy: 
+    src: /home/{{username}}/{{ version_name }}/code-server
+    dest: /opt/code-server
+    remote_src: yes
+    mode: '0744'
+    owner: "{{username}}"
+    group: "{{username}}"
+
+- name: Apply systemd service file
+  template: 
+    src: ../files/code-server.service.j2
+    dest: /etc/systemd/system/code-server.service
+    owner: "{{username}}"
+    group: wheel
+    mode: '0744'
+
+- name: Start code-server service
+  service:
+    name: code-server
+    state: started
+    enabled: yes   
+
+- name: Cleanup Coder binary from student directory
+  file: 
+    path: /home/{{username}}/{{ version_name }}
+    state: absent
+
 - name: setup control node networking
   include_tasks: "networking.yml"
   when: workshop_type in ['networking', 'f5']


### PR DESCRIPTION
##### SUMMARY
Introduces support for the [Coder](https://github.com/cdr/code-server) project as a default way to teach Ansible exercises in an IDE rather than solely via CLI.

To use the IDE, access the control node at port 8080, for example:
_http://192.168.1.1:8080_
_The above is not a valid IP for the purposes of this material and is intended to be only an example_
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
The Coder project is based on [Visual Studio Code ](https://github.com/microsoft/vscode) and offers the most mature Ansible extension available to any web based IDE. Full key bindings should be supported, and the Ansible Extension is pre-installed for the workshop environment.

This initial deployment of Coder is as a systemd based service with limited functionality.

Coder in this instance also does not have authentication and does not have SSL encryption enabled for the sake of introducing it for further approval and iteration. The project offers many robust authentication capabilities, and should be modified before considering it's usage in any production environment where data or credentials could be compromised.




