### PR TITLE
Fix SHELL running multiple times + folder paths

### DIFF
--- a/vagrant-demo/Vagrantfile
+++ b/vagrant-demo/Vagrantfile
@@ -1,4 +1,4 @@
-# Generic leaf-spine network topology for vagrant
+    # Generic leaf-spine network topology for vagrant
 #
 #
 #
@@ -9,10 +9,11 @@
 Vagrant.require_version ">= 2.1.1"
 
 $script = <<SCRIPT
-git clone https://github.com/network-automation/linklight/
-chown -R vagrant:vagrant linklight
-cp /home/vagrant/linklight/vagrant-demo/arista/ansible.cfg /home/vagrant/.ansible.cfg
-cp /home/vagrant/linklight/vagrant-demo/arista/etchosts /etc/hosts
+git clone https://github.com/network-automation/workshops/
+chown -R vagrant:vagrant workshops
+cp /home/vagrant/workshops/vagrant-demo/ansible.cfg /home/vagrant/.ansible.cfg
+cp /home/vagrant/workshops/vagrant-demo/etchosts /etc/hosts
+yum install epel-release -y
 yum install python-pip tree -y
 pip install --upgrade pip
 pip install git+https://github.com/ansible/ansible.git@devel
@@ -40,11 +41,11 @@ Vagrant.configure("2") do |config|
 
   ##### DEFINE VM for ansible tower #####
   config.vm.define "ansible" do |device|
-      device.vm.hostname = "ansible"
-      device.vm.box = "ansible/tower"
-      device.vm.network :forwarded_port, guest: 22, host: 6010
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", ip: "192.168.0.2"
-      device.vm.provision "shell", inline: $script
+    device.vm.hostname = "ansible"
+    device.vm.box = "ansible/tower"
+    device.vm.network :forwarded_port, guest: 22, host: 6010
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", ip: "192.168.0.2"
+    device.vm.provision "shell", inline: $script
   end
 
   ##### DEFINE VM for leaf01 #####
@@ -58,25 +59,25 @@ Vagrant.configure("2") do |config|
       v.memory = network_memory
     end
 
-    config.vm.provision 'shell', inline: <<-SHELL
-     FastCli -p 15 -c "configure
-     hostname leaf01
-     int e1
-     no switchport
-     ip address 192.168.0.14/24
-     end
-     copy running-config startup-config"
+    device.vm.provision "leaf01_shell_config", type: 'shell', inline: <<-SHELL
+      FastCli -p 15 -c "configure
+      hostname leaf01
+      int e1
+      no switchport
+      ip address 192.168.0.14/24
+      end
+      copy running-config startup-config"
     SHELL
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
     device.vm.synced_folder ".", "/vagrant", disabled: true
 
     # NETWORK INTERFACES
-      # eth1 mgmt network for ansible tower
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
-      # link for eth2 --> spine01:eth2
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false
-      # link for eth3 --> spine02:eth2
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false
+    # eth1 mgmt network for ansible tower
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
+    # link for eth2 --> spine01:eth2
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false
+    # link for eth3 --> spine02:eth2
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -87,27 +88,27 @@ Vagrant.configure("2") do |config|
       vbox.customize ['modifyvm', :id, '--nicpromisc7', 'allow-all']
       vbox.customize ['modifyvm', :id, '--nicpromisc8', 'allow-all']
     end
-end
- ##### DEFINE VM for leaf02 #####
- config.vm.define "leaf02" do |device|
+  end
+  ##### DEFINE VM for leaf02 #####
+  config.vm.define "leaf02" do |device|
 
-   device.vm.hostname = "leaf02"
-   device.vm.box = "#{network_os}"
+    device.vm.hostname = "leaf02"
+    device.vm.box = "#{network_os}"
     device.vm.network "forwarded_port", guest: 22, host: 6002
-   device.vm.provider "virtualbox" do |v|
-     v.name = "#{simid}_leaf02"
-     v.customize ["modifyvm", :id, '--audiocontroller', 'AC97', '--audio', 'Null']
-     v.memory = network_memory
-   end
-   #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
-    config.vm.provision 'shell', inline: <<-SHELL
-     FastCli -p 15 -c "configure
-     hostname leaf02
-     int e1
-     no switchport
-     ip address 192.168.0.15/24
-     end
-     copy running-config startup-config"
+    device.vm.provider "virtualbox" do |v|
+      v.name = "#{simid}_leaf02"
+      v.customize ["modifyvm", :id, '--audiocontroller', 'AC97', '--audio', 'Null']
+      v.memory = network_memory
+    end
+    #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
+    device.vm.provision "leaf02_shell_config", type: 'shell', inline: <<-SHELL
+      FastCli -p 15 -c "configure
+      hostname leaf02
+      int e1
+      no switchport
+      ip address 192.168.0.15/24
+      end
+      copy running-config startup-config"
     SHELL
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
     device.vm.synced_folder ".", "/vagrant", disabled: true
@@ -121,15 +122,15 @@ end
     device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false
 
 
-   device.vm.provider "virtualbox" do |vbox|
-     vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
-     vbox.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
-     vbox.customize ['modifyvm', :id, '--nicpromisc4', 'allow-all']
-     vbox.customize ['modifyvm', :id, '--nicpromisc5', 'allow-all']
-     vbox.customize ['modifyvm', :id, '--nicpromisc6', 'allow-all']
-     vbox.customize ['modifyvm', :id, '--nicpromisc7', 'allow-all']
-   end
-end
+    device.vm.provider "virtualbox" do |vbox|
+      vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
+      vbox.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
+      vbox.customize ['modifyvm', :id, '--nicpromisc4', 'allow-all']
+      vbox.customize ['modifyvm', :id, '--nicpromisc5', 'allow-all']
+      vbox.customize ['modifyvm', :id, '--nicpromisc6', 'allow-all']
+      vbox.customize ['modifyvm', :id, '--nicpromisc7', 'allow-all']
+    end
+  end
 
   ##### DEFINE VM for spine01 #####
   config.vm.define "spine01" do |device|
@@ -143,25 +144,25 @@ end
       v.memory = network_memory
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
-    config.vm.provision 'shell', inline: <<-SHELL
-     FastCli -p 15 -c "configure
-     hostname spine01
-     int e1
-     no switchport
-     ip address 192.168.0.10/24
-     end
-     copy running-config startup-config"
+    device.vm.provision "spine01_shell_config", type: 'shell', inline: <<-SHELL
+      FastCli -p 15 -c "configure
+      hostname spine01
+      int e1
+      no switchport
+      ip address 192.168.0.10/24
+      end
+      copy running-config startup-config"
     SHELL
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
     device.vm.synced_folder ".", "/vagrant", disabled: true
 
     # NETWORK INTERFACES
-      # eth1 mgmt network for ansible tower
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
-      # link for spine01:eth2 --> leaf01:eth2
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false
-      # link for spine01:eth3 --> leaf02:eth2
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false
+    # eth1 mgmt network for ansible tower
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
+    # link for spine01:eth2 --> leaf01:eth2
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net2", auto_config: false
+    # link for spine01:eth3 --> leaf02:eth2
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net13", auto_config: false
 
 
     device.vm.provider "virtualbox" do |vbox|
@@ -170,9 +171,9 @@ end
       vbox.customize ['modifyvm', :id, '--nicpromisc4', 'allow-all']
       vbox.customize ['modifyvm', :id, '--nicpromisc5', 'allow-all']
     end
-end
+  end
 
-  ##### DEFINE VM for spine02 #####
+##### DEFINE VM for spine02 #####
   config.vm.define "spine02" do |device|
 
     device.vm.hostname = "spine02"
@@ -184,25 +185,25 @@ end
       v.memory = network_memory
     end
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
-    config.vm.provision 'shell', inline: <<-SHELL
-     FastCli -p 15 -c "configure
-     hostname spine02
-     int e1
-     no switchport
-     ip address 192.168.0.11/24
-     end
-     copy running-config startup-config"
+    device.vm.provision "spine02_shell_config", type: 'shell', inline: <<-SHELL
+      FastCli -p 15 -c "configure
+      hostname spine02
+      int e1
+      no switchport
+      ip address 192.168.0.11/24
+      end
+      copy running-config startup-config"
     SHELL
     #   see note here: https://github.com/pradels/vagrant-libvirt#synced-folders
     device.vm.synced_folder ".", "/vagrant", disabled: true
 
     # NETWORK INTERFACES
-      # eth1 mgmt network for ansible tower
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
-      # link for spine02:eth2 --> leaf01:eth3
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false
-      # link for spine02:eth3 --> leaf02:eth3
-      device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false
+    # eth1 mgmt network for ansible tower
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_mgmt", auto_config: false
+    # link for spine02:eth2 --> leaf01:eth3
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net12", auto_config: false
+    # link for spine02:eth3 --> leaf02:eth3
+    device.vm.network "private_network", virtualbox__intnet: "#{simid}_net15", auto_config: false
 
     device.vm.provider "virtualbox" do |vbox|
       vbox.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
@@ -210,8 +211,5 @@ end
       vbox.customize ['modifyvm', :id, '--nicpromisc4', 'allow-all']
       vbox.customize ['modifyvm', :id, '--nicpromisc5', 'allow-all']
     end
-end
-
-
-
+  end
 end


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The vagrant-demo Vagrantfile additions are:
- Clean up references to the name linklight.
- Addition of EPEL repository to tower VM to allow install of PIP.
- Change of _vm_ definitions to allow the aporpate SHELL CLI script for the defined VM.
  -  Documentation to show that you can change _config.vm.provision_ to _device.vm.provision_ [Vagrant: multi-machine](https://www.vagrantup.com/docs/multi-machine/)
- Altered indentations.


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before**
```
$ vagrant provision leaf01
==> leaf01: Running provisioner: shell...
    leaf01: Running: inline script
    leaf01: Copy completed successfully.
==> leaf01: Running provisioner: shell...
    leaf01: Running: inline script
    leaf01: Copy completed successfully.
==> leaf01: Running provisioner: shell...
    leaf01: Running: inline script
    leaf01: Copy completed successfully.
==> leaf01: Running provisioner: shell...
    leaf01: Running: inline script
    leaf01: Copy completed successfully.
```
**After**
```
$ vagrant provision leaf01
==> leaf01: Running provisioner: leaf01_shell_config (shell)...
    leaf01: Running: inline script
    leaf01: Copy completed successfully.
```
