### PR TITLE
Update teardown.yml

### DIFF
--- a/provisioner/roles/aws_dns/tasks/teardown.yml
+++ b/provisioner/roles/aws_dns/tasks/teardown.yml
@@ -4,12 +4,12 @@
   register: AWSINFO
 
 - name: GRAB ROUTE53 INFORMATION
-  route53_facts:
+  route53_info:
     type: A
     query: record_sets
     hosted_zone_id: "{{AWSINFO.zone_id}}"
     start_record_name: "student1.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
-    max_items: "{{student_total|string}}"
+    max_items: "{% if ansible_version.minor <= 8 %}{{student_total|string}}{% else %}{{student_total|int}}{% endif %}"
   register: record_sets
 
 - name: DELETE DNS ENTRIES FOR EACH STUDENT

--- a/provisioner/roles/aws_dns/tasks/teardown.yml
+++ b/provisioner/roles/aws_dns/tasks/teardown.yml
@@ -9,7 +9,7 @@
     query: record_sets
     hosted_zone_id: "{{AWSINFO.zone_id}}"
     start_record_name: "student1.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
-    max_items: "{% if ansible_version.minor <= 8 %}{{student_total|string}}{% else %}{{student_total|int}}{% endif %}"
+    max_items: "{% if ansible_version.minor <= 9 %}{{student_total|string}}{% else %}{{student_total|int}}{% endif %}"
   register: record_sets
 
 - name: DELETE DNS ENTRIES FOR EACH STUDENT

--- a/provisioner/roles/aws_dns/tasks/teardown.yml
+++ b/provisioner/roles/aws_dns/tasks/teardown.yml
@@ -4,7 +4,7 @@
   register: AWSINFO
 
 - name: GRAB ROUTE53 INFORMATION
-  route53_info:
+  route53_facts:
     type: A
     query: record_sets
     hosted_zone_id: "{{AWSINFO.zone_id}}"


### PR DESCRIPTION
##### SUMMARY
this addresses https://github.com/ansible/ansible/issues/64534

this is a  workaround for 2.10 issue with route53 that allows backwards compatibility with 2.9 and older

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
@Spredzy is super cool
