### PR TITLE
[WIP] Improve verification checks, add walkthrough test

### DIFF
--- a/exercises/ansible_security/1.2-checkpoint/playbooks/web_attack_simulation.yml
+++ b/exercises/ansible_security/1.2-checkpoint/playbooks/web_attack_simulation.yml
@@ -1,0 +1,9 @@
+---
+- name: start attack
+  hosts: attacker
+  become: yes
+  gather_facts: no
+
+  tasks:
+    - name: simulate attack every 5 seconds
+      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -s http://{{ hostvars['snort']['private_ip2'] }}/web_attack_simulation"

--- a/exercises/ansible_security/1.2-checkpoint/playbooks/whitelist_attacker.yml
+++ b/exercises/ansible_security/1.2-checkpoint/playbooks/whitelist_attacker.yml
@@ -1,0 +1,35 @@
+---
+- name: Whitelist attacker
+  hosts: checkpoint
+
+  vars:
+    source_ip: "{{ hostvars['attacker']['private_ip2'] }}"
+    destination_ip: "{{ hostvars['snort']['private_ip2'] }}"
+
+  tasks:
+    - name: Create source IP host object
+      checkpoint_host:
+        name: "asa-{{ source_ip }}"
+        ip_address: "{{ source_ip }}"
+
+    - name: Create destination IP host object
+      checkpoint_host:
+        name: "asa-{{ destination_ip }}"
+        ip_address: "{{ destination_ip }}"
+
+    - name: Create access rule to allow access from source to destination
+      checkpoint_access_rule:
+        auto_install_policy: yes
+        auto_publish_session: yes
+        layer: Network
+        position: top
+        name: "asa-accept-{{ source_ip }}-to-{{ destination_ip }}"
+        source: "asa-{{ source_ip }}"
+        destination: "asa-{{ destination_ip }}"
+        action: accept
+
+    - name: Install policy
+      cp_mgmt_install_policy:
+        policy_package: standard
+        install_on_all_cluster_members_or_fail: yes
+      failed_when: false

--- a/exercises/ansible_security/2.1-suspicious/playbooks/triage_log_sources.yml.j2
+++ b/exercises/ansible_security/2.1-suspicious/playbooks/triage_log_sources.yml.j2
@@ -1,0 +1,61 @@
+---
+- name: Configure snort for external logging
+  hosts: snort
+  become: true
+  vars:
+    ids_provider: "snort"
+    ids_config_provider: "snort"
+    ids_config_remote_log: true
+    ids_config_remote_log_destination: "{{ '{{' }} hostvars['qradar']['private_ip'] {{ '}}' }}"
+    ids_config_remote_log_procotol: udp
+    ids_install_normalize_logs: false
+
+  tasks:
+    - name: import ids_config role
+      include_role:
+        name: "ansible_security.ids_config"
+
+- name: Add Snort log source to QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Add snort remote logging to QRadar
+      qradar_log_source_management:
+        name: "Snort rsyslog source - {{ '{{' }} hostvars['snort']['private_ip'] {{ '}}' }}"
+        type_name: "Snort Open Source IDS"
+        state: present
+        description: "Snort rsyslog source"
+        identifier: "{{ '{{' }} hostvars['snort']['private_ip']|regex_replace('\\.','-')|regex_replace('^(.*)$', 'ip-\\1') {{ '}}' }}"
+
+- name: Configure Check Point to send logs to QRadar
+  hosts: checkpoint
+
+  tasks:
+    - include_role:
+        name: ansible_security.log_manager
+        tasks_from: forward_logs_to_syslog
+      vars:
+        syslog_server: "{{ '{{' }} hostvars['qradar']['private_ip'] {{ '}}' }}"
+        checkpoint_server_name: "{{ cp_mngmt_server_name }}"
+        firewall_provider: checkpoint
+
+- name: Add Check Point log source to QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Add Check Point remote logging to QRadar
+      qradar_log_source_management:
+        name: "Check Point source - {{ '{{' }} hostvars['checkpoint']['private_ip'] {{ '}}' }}"
+        type_name: "Check Point FireWall-1"
+        state: present
+        description: "Check Point log source"
+        identifier: "{{ '{{' }} hostvars['checkpoint']['private_ip'] {{ '}}' }}"
+
+    - name: deploy the new log sources
+      qradar_deploy:
+        type: INCREMENTAL
+      failed_when: false

--- a/provisioner/roles/manage_ec2_instances/templates/instructor_inventory_security.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/instructor_inventory_security.j2
@@ -26,12 +26,12 @@ ansible_port={{ ssh_port }}
 {% endif %}
 {% for host in snort_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{host.tags.Student}}-snort ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
+{{host.tags.Student}}-snort ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} private_ip={{ hostvars[host.tags.Name]['private_ip'] }} private_ip2={{ hostvars[host.tags.Name]['private_ip2'] }}
 {% endif %}
 {% endfor %}
 {% for host in attacker_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{{host.tags.Student}}-attacker ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }}
+{{host.tags.Student}}-attacker ansible_host={{ host.public_ip_address }} ansible_user={{ host.tags.username }} private_ip={{ hostvars[host.tags.Name]['private_ip'] }} private_ip2={{ hostvars[host.tags.Name]['private_ip2'] }}
 {% endif %}
 {% endfor %}
 {% for host in checkpoint_node_facts.instances %}

--- a/provisioner/roles/manage_ec2_instances/templates/security_instances.txt.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/security_instances.txt.j2
@@ -5,17 +5,17 @@ ansible_ssh_pass={{ admin_password }}
 ansible_port={{ ssh_port }}
 {% endif %}
 
-[attack]
-{% for vm in attacker_node_facts.instances %}
-{% if 'student' + item == vm.tags.Student %}
-attacker ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} private_ip={{ vm.private_ip_address }} private_ip2={{ vm['network_interfaces'][1]['private_ip_address'] }}
-{% endif %}
-{% endfor %}
-
 [control]
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-ansible ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} private_ip={{ vm.private_ip_address }}
+ansible ansible_host={{ vm.public_ip_address }} private_ip={{ hostvars[vm.tags.Name]['private_ip'] }}
+{% endif %}
+{% endfor %}
+
+[attack]
+{% for vm in attacker_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+attacker ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} private_ip={{ hostvars[vm.tags.Name]['private_ip'] }} private_ip2={{ hostvars[vm.tags.Name]['private_ip2'] }}
 {% endif %}
 {% endfor %}
 
@@ -23,14 +23,14 @@ ansible ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username
 {% if security_console == 'splunk' %}
 {% for vm in splunk_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-splunk ansible_host={{ vm.public_ip_address }} ansible_user=admin private_ip={{ vm.private_ip_address }} ansible_httpapi_pass="Ansible1!" ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=False ansible_network_os=splunk.enterprise_security.splunk
+splunk ansible_host={{ vm.public_ip_address }} ansible_user=admin private_ip={{ hostvars[vm.tags.Name]['private_ip'] }} ansible_httpapi_pass="Ansible1!" ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=False ansible_network_os=splunk.enterprise_security.splunk
 {% endif %}
 {% endfor %}
 {% endif %}
 {% if security_console == 'qradar' %}
 {% for vm in qradar_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-qradar ansible_host={{ vm.public_ip_address }} ansible_user=admin private_ip={{ vm.private_ip_address }} ansible_httpapi_pass="Ansible1!" ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=False ansible_network_os=ibm.qradar.qradar
+qradar ansible_host={{ vm.public_ip_address }} ansible_user=admin private_ip={{ hostvars[vm.tags.Name]['private_ip'] }} ansible_httpapi_pass="Ansible1!" ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=False ansible_network_os=ibm.qradar.qradar
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -38,20 +38,20 @@ qradar ansible_host={{ vm.public_ip_address }} ansible_user=admin private_ip={{ 
 [ids]
 {% for vm in snort_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-snort ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} private_ip={{ vm.private_ip_address }} private_ip2={{ vm['network_interfaces'][1]['private_ip_address'] }}
+snort ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} private_ip={{ hostvars[vm.tags.Name]['private_ip'] }} private_ip2={{ hostvars[vm.tags.Name]['private_ip2'] }}
 {% endif %}
 {% endfor %}
 
 [firewall]
 {% for vm in checkpoint_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-checkpoint ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} ansible_password=admin123 private_ip={{ vm.private_ip_address }} ansible_network_os=checkpoint ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=no
+checkpoint ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} ansible_password=admin123 private_ip={{ hostvars[vm.tags.Name]['private_ip'] }} ansible_network_os=checkpoint ansible_connection=httpapi ansible_httpapi_use_ssl=yes ansible_httpapi_validate_certs=no
 {% endif %}
 {% endfor %}
 
 [windows]
 {% for vm in windows_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-windows-ws ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} ansible_pass={{ windows_password}} ansible_port=5986 ansible_connection=winrm ansible_winrm_server_cert_validation=ignore private_ip={{ vm.private_ip_address }}
+windows-ws ansible_host={{ vm.public_ip_address }} ansible_user={{ vm.tags.username }} ansible_pass={{ windows_password}} ansible_port=5986 ansible_connection=winrm ansible_winrm_server_cert_validation=ignore private_ip={{ hostvars[vm.tags.Name]['private_ip'] }}
 {% endif %}
 {% endfor %}

--- a/provisioner/tests/security_exercise_21.yml
+++ b/provisioner/tests/security_exercise_21.yml
@@ -1,0 +1,103 @@
+---
+- name: Step 1, Step 2 - Preparations 1/2
+  hosts: control
+  gather_facts: no
+  
+  tasks:
+    - name: copy web_attack_simulation.yml to control nodes
+      copy:
+        src: ../../exercises/ansible_security/1.2-checkpoint/playbooks/web_attack_simulation.yml
+        dest: web_attack_simulation.yml 
+    
+    - name: execute web_attack_simulation.yml  on control nodes
+      command: /usr/bin/ansible-playbook web_attack_simulation.yml 
+
+    - name: install required roles
+      command: "ansible-galaxy install {{ item }}"
+      loop:
+        - ansible_security.ids_rule
+        - ansible_security.ids_config
+        - ansible_security.log_manager
+
+    - name: install required collections
+      command: "ansible-galaxy collection install {{ item }}"
+      loop:
+        - ibm.qradar
+
+- name: Step 1.5 - Verify that traffic is blacklisted
+  hosts: ids
+  gather_facts: no
+  become: yes
+
+  tasks:
+    - name: Verify attack string in log file
+      command: grep web_attack /var/log/httpd/access_log
+      register: grep_result
+      failed_when: grep_result.rc == 0
+
+- name: Step 1, Step 2 - Preparations 2/2
+  hosts: control
+  gather_facts: no
+  
+  tasks:
+    - name: copy whitelist_attacker.yml to control nodes
+      copy:
+        src: ../../exercises/ansible_security/1.2-checkpoint/playbooks/whitelist_attacker.yml
+        dest: whitelist_attacker.yml
+    
+    - name: execute whitelist_attacker.yml on control nodes
+      command: /usr/bin/ansible-playbook whitelist_attacker.yml
+
+- name: Step 3 - Verify anomaly
+  hosts: ids
+  gather_facts: no
+  become: yes
+
+  tasks:
+    - name: Verify attack string in log file
+      command: grep web_attack /var/log/httpd/access_log
+
+- name: Step 4, Step 5 - Create and execute triage_log playbook
+  hosts: control
+  gather_facts: no
+
+  tasks:
+    - name: Get Check Point MGMT server name, step 1/2 - login, get SID
+      uri:
+        url: "https://{{ hostvars['checkpoint']['ansible_host'] }}/web_api/login"
+        method: POST
+        body:
+          user: admin
+          password: admin123
+        body_format: json
+        validate_certs: no
+      register: login_data
+      until: (login_data.status == 200) and (login_data.json is defined)
+      retries: 30
+      delay: 10
+
+    - name: Get Check Point MGMT server name, step 2/2 - Get server name
+      uri:
+        url: "https://{{ hostvars['checkpoint']['ansible_host'] }}/web_api/show-gateways-and-servers"
+        validate_certs: no
+        method: POST
+        headers:
+          Content-Type: application/json
+          X-chkp-sid: "{{ login_data.json.sid }}"
+        body_format: json
+        body: >
+          {}
+        return_content: yes
+      register: mgmt_data
+
+    - name: set server name as fact
+      set_fact:
+        cp_mngmt_server_name: "{{ mgmt_data.json.objects | selectattr('type', 'equalto', 'CpmiHostCkp')|map(attribute='name')|join(',') }}"
+
+    - name: deploy triage_log_sources.yml template to control nodes
+      template:
+        src: ../../exercises/ansible_security/2.1-suspicious/playbooks/triage_log_sources.yml.j2
+        dest: triage_log_sources.yml
+
+    - name: execute triage_log_sources.yml on control nodes
+      command: /usr/bin/ansible-playbook triage_log_sources.yml

--- a/provisioner/tests/security_verify.yml
+++ b/provisioner/tests/security_verify.yml
@@ -33,6 +33,11 @@
           msg: "IP address setup on ethX is not right on {{ inventory_hostname }}."
         when: (((hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] | ipaddr('172.16.0.0/16') | string) is not search('172')) or ((hostvars[inventory_hostname]['ansible_eth1']['ipv4']['address'] | ipaddr('172.17.0.0/16') | string) is not search('172')))
 
+      - name: Fail if private_ip is not in 172.16. or private_ip2 is not in 172.17.
+        fail:
+          msg: "IP address setup on ethX is not right on {{ inventory_hostname }}."
+        when: (((hostvars[inventory_hostname]['private_ip'] | ipaddr('172.16.0.0/16') | string) is not search('172')) or ((hostvars[inventory_hostname]['private_ip2'] | ipaddr('172.17.0.0/16') | string) is not search('172')))
+
       when: '"attack" in inventory_hostname'
 
     - name: Snort
@@ -51,6 +56,10 @@
           msg: "IP address setup on ethX is not right on {{ inventory_hostname }}."
         when: (((hostvars[inventory_hostname]['ansible_eth0']['ipv4']['address'] | ipaddr('172.16.0.0/16') | string) is not search('172')) or ((hostvars[inventory_hostname]['ansible_eth1']['ipv4']['address'] | ipaddr('172.17.0.0/16') | string) is not search('172')))
 
+      - name: Fail if private_ip is not in 172.16. or private_ip2 is not in 172.17.
+        fail:
+          msg: "IP address setup on ethX is not right on {{ inventory_hostname }}."
+        when: (((hostvars[inventory_hostname]['private_ip'] | ipaddr('172.16.0.0/16') | string) is not search('172')) or ((hostvars[inventory_hostname]['private_ip2'] | ipaddr('172.17.0.0/16') | string) is not search('172')))
       when: '"snort" in inventory_hostname'
 
     - name: Check Point - Windows part


### PR DESCRIPTION
##### SUMMARY

- add private_ip and private_ip2 to instructor inventory
- streamline private_ip and private_ip2 variable in inventories, all are
now referenced in the same way (private_ip_address is bad if you have
two priavte IP addresses)
- remove wrong (!) ec2-user user from control entry in student
inventory, they will use the student user
- add check to verify that inventory entries for private_ips are correct
- rename verify playbook to security_verify
- add playbook to walk through the exercise 2.1
- add part in there to verify that the FW is actually blocking traffic!
- add playbooks which are necessary for exercise 2.1 in the
corresponding exercises (2.1 and 1.2)

The walkthrough playbook must be called with key (for snort access) but the control auth is via pwd. Sometimes this fails on the control host. Might need to check if we can fix this.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- provisioner
