### PR TITLE
fixing error with pysnow

### DIFF
--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -22,7 +22,6 @@
   pip:
     name:
       - netaddr
-      - pysnow
       - ncclient
     state: latest
   when: workshop_type == 'networking'

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -26,7 +26,7 @@
     state: latest
   when: workshop_type == 'networking'
 
-# FIXME: This should probably be refactored to use things like the following
+# FIX ME: This should probably be refactored to use things like the following
 # instead of hard coding
 #
 #   command: cp -r /tmp/linklight/exercises/{{workshop_type}}/ /home/{{ username }}/{{workshop_type}}-workshop/

--- a/provisioner/roles/control_node/tasks/networking.yml
+++ b/provisioner/roles/control_node/tasks/networking.yml
@@ -26,7 +26,7 @@
     state: latest
   when: workshop_type == 'networking'
 
-# FIX ME: This should probably be refactored to use things like the following
+# FIXME: This should probably be refactored to use things like the following
 # instead of hard coding
 #
 #   command: cp -r /tmp/linklight/exercises/{{workshop_type}}/ /home/{{ username }}/{{workshop_type}}-workshop/


### PR DESCRIPTION
##### SUMMARY
workshops seem broken even on stable... this is due to a bug with pysnow
gist: https://gist.github.com/IPvSean/d47b0219a5bdf0fc08c36ce976fc6804

for folks with access to red hat jenkins:
http://jenkins.ansible.eng.rdu2.redhat.com/blue/organizations/jenkins/tower-qe-compatibility-pipepline/detail/tower-qe-compatibility-pipepline/596/pipeline#step-81-log-564

module that does this for workshop provisioner:
https://github.com/ansible/workshops/blob/master/provisioner/roles/control_node/tasks/networking.yml#L20
##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
this is an error stopping provisioning, we need to fix ASAP for network automation type
