### PR TITLE
Removing ToC

### DIFF
--- a/exercises/ansible_windows/1-tower/exercise1.md
+++ b/exercises/ansible_windows/1-tower/exercise1.md
@@ -1,27 +1,3 @@
-Table of Contents
-=================
-
-- [Agenda](index.html)
-
-- [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
-- [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
-- [Exercise 3 - Writing Your First playbook](exercise3.html)
-
-- [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
-- [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
-- [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
-- [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
-- [Wrap UP](wrapup.html)
-
-In this exercise, we are going to configure Ansible Tower so that we can
-run a playbook.
-
 Configuring Ansible Tower
 =========================
 

--- a/exercises/ansible_windows/2-adhoc/exercise2.md
+++ b/exercises/ansible_windows/2-adhoc/exercise2.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
-- [Agenda](index.html)
-
-- [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
-- [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
-- [Exercise 3 - Writing Your First playbook](exercise3.html)
-
-- [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
-- [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
-- [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
-- [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
-- [Wrap UP](wrapup.html)
-
 Section 1: Ad-hoc commands
 ==========================
 
@@ -338,7 +317,7 @@ And now reboot the host.
 </table>
 
 > **Note**
-> 
+>
 > The `win_reboot` module will cause the machine to reboot, and then will
 > wait for it to come completely back up before finishing. This way, if
 > you need to reboot the host in the middle of your playbook, the rest

--- a/exercises/ansible_windows/3-playbook/exercise3.md
+++ b/exercises/ansible_windows/3-playbook/exercise3.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
-- [Agenda](index.html)
-
-- [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
-- [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
-- [Exercise 3 - Writing Your First playbook](exercise3.html)
-
-- [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
-- [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
-- [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
-- [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
-- [Wrap UP](wrapup.html)
-
 Let’s begin by writing our first ansible **playbook**. The playbook is
 where you list the steps you would like to automate into a repeatable
 set of **plays** and **tasks**. To begin we will setup our directory
@@ -123,12 +102,12 @@ of this exercise.
          win_feature:
            name: Web-Server
            state: present
-    
+
        - name: start iis service
          win_service:
            name: W3Svc
            state: started
-    
+
        - name: Create website index.html
          win_copy:
            content: "{{ iis_test_message }}"
@@ -221,7 +200,7 @@ you should see your repository.
 You are ready to automate!
 
 > **Note**
-> 
+>
 > Ansible (well, YAML really) can be a bit particular about formatting
 > especially around indentation/spacing. When you all get back to the
 > office, read up on this [YAML
@@ -233,18 +212,18 @@ You are ready to automate!
     ---
     - name: install the iis web service
       hosts: all
-    
+
       tasks:
         - name: install iis
           win_feature:
             name: Web-Server
             state: present
-    
+
         - name: start iis service
           win_service:
             name: W3Svc
             state: started
-    
+
         - name: Create website index.html
           win_copy:
             content: "{{ iis_test_message }}"

--- a/exercises/ansible_windows/4-projects/exercise4.md
+++ b/exercises/ansible_windows/4-projects/exercise4.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
-- [Agenda](index.html)
-
-- [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
-- [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
-- [Exercise 3 - Writing Your First playbook](exercise3.html)
-
-- [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
-- [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
-- [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
-- [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
-- [Wrap UP](wrapup.html)
-
 A job template is a definition and set of parameters for running an
 Ansible job. Job templates are useful to execute the same job many
 times.
@@ -175,7 +154,7 @@ Step 1:
 Select TEMPLATES
 
 > **Note**
-> 
+>
 > Alternatively, if you haven’t navigated away from the job templates
 > creation page, you can scroll down to see all existing job templates
 

--- a/exercises/ansible_windows/5-adv-playbook/exercise5.md
+++ b/exercises/ansible_windows/5-adv-playbook/exercise5.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
-- [Agenda](index.html)
-
-- [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
-- [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
-- [Exercise 3 - Writing Your First playbook](exercise3.html)
-
-- [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
-- [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
-- [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
-- [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
-- [Wrap UP](wrapup.html)
-
 Previous exercises showed you the basics of Ansible playbooks. In the
 next few exercises, we are going to teach some more advanced ansible
 skills that will add flexibility and power to your playbooks.
@@ -114,13 +93,13 @@ Add a new task called **install IIS**. After writing the playbook, click
           win_feature:
             name: Web-Server
             state: present
-    
+
         - name: Create site directory structure
           win_file:
             path: "{{ item.path }}"
             state: directory
           with_items: "{{ iis_sites }}"
-    
+
         - name: Create IIS site
           win_iis_website:
             name: "{{ item.name }}"
@@ -133,27 +112,27 @@ Add a new task called **install IIS**. After writing the playbook, click
 ![site.yml part 1](images/5-vscode-iis-yaml.png)
 
 > **Note**
-> 
+>
 > **What is happening here!?**  
-> 
+>
 > - `vars:` You’ve told Ansible the next thing it sees will be a
 >   variable name  
-> 
+>
 > - `iis_sites` You are defining a list-type variable called
 >   iis\_sites. What follows is a list of each site with it’s related
 >   variables  
-> 
+>
 > - `file:` This module is used to create, modify, delete files,
 >   directories, and symlinks.
-> 
+>
 > - `{{ item }}` You are telling Ansible that this will expand into a
 >   list item. Each item has several variables like `name`, `port`,
 >   and `path`.  
-> 
+>
 > - `with_items: "{{ iis_sites }}` This is your loop which is
 >   instructing Ansible to perform this task on every `item` in
 >   `iis_sites`
-> 
+>
 > - `notify: restart iis service` This statement is a `handler`, so
 >   we’ll come back to it in Section 3.
 
@@ -182,10 +161,10 @@ for creating your template. Enter the following details:
 
     <html>
     <body>
-    
+
       <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
       <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
-    
+
     </body>
     </html>
 
@@ -208,7 +187,7 @@ not escape the forward slash.
             direction: In
             protocol: Tcp
           with_items: "{{ iis_sites }}"
-    
+
         - name: Template simple web site to iis_site_path as index.html
           win_template:
             src: 'index.html.j2'
@@ -216,17 +195,17 @@ not escape the forward slash.
           with_items: "{{ iis_sites }}"
 
 > **Note**
-> 
+>
 > **So… what did I just write?**
-> 
+>
 > - `win_firewall_rule:` This module is used to create, modify, and
 >   update firewall rules. Note in the case of AWS there are also
 >   security group rules which may impact communication. We’ve opened
 >   these for the ports in this example.
-> 
+>
 > - `win_template:` This module specifies that a jinja2 template is
 >   being used and deployed.
-> 
+>
 > - used in Ansible to transform data inside a template expression,
 >   i.e. filters.
 
@@ -255,15 +234,15 @@ Define a handler.
             start_mode: auto
 
 > **Note**
-> 
+>
 > **You can’t have a former if you don’t mention the latter**
-> 
+>
 > - `handler:` This is telling the **play** that the `tasks:` are
 >   over, and now we are defining `handlers:`. Everything below that
 >   looks the same as any other task, i.e. you give it a name, a
 >   module, and the options for that module. This is the definition of
 >   a handler.
-> 
+>
 > - `notify: restart iis service` …and here is your latter. Finally!
 >   The `notify` statement is the invocation of a handler by name.
 >   Quite the reveal, we know. You already noticed that you’ve added a
@@ -309,19 +288,19 @@ shows line counts and spacing.
             port: '8081'
             path: 'C:\sites\playbooktest2'
         iis_test_message: "Hello World!  My test IIS Server"
-    
+
       tasks:
         - name: Install IIS
           win_feature:
             name: Web-Server
             state: present
-    
+
         - name: Create site directory structure
           win_file:
             path: "{{ item.path }}"
             state: directory
           with_items: "{{ iis_sites }}"
-    
+
         - name: Create IIS site
           win_iis_website:
             name: "{{ item.name }}"
@@ -330,7 +309,7 @@ shows line counts and spacing.
             physical_path: "{{ item.path }}"
           with_items: "{{ iis_sites }}"
           notify: restart iis service
-    
+
         - name: Open port for site on the firewall
           win_firewall_rule:
             name: "iisport{{ item.port }}"
@@ -341,13 +320,13 @@ shows line counts and spacing.
             direction: In
             protocol: Tcp
           with_items: "{{ iis_sites }}"
-    
+
         - name: Template simple web site to iis_site_path as index.html
           win_template:
             src: 'index.html.j2'
             dest: '{{ item.path }}\index.html'
           with_items: "{{ iis_sites }}"
-    
+
       handlers:
         - name: restart iis service
           win_service:
@@ -365,7 +344,7 @@ Before we can create our Job Template, you must first go resync your
 Project again. So do that now.
 
 > **Note**
-> 
+>
 > You must do this anytime you create a new *base* playbook file that
 > you will be selecting via a Job Template. The new file must be synced
 > to Tower before it will become available in the Job Template playbook
@@ -502,7 +481,7 @@ Step 1:
 Select TEMPLATES
 
 > **Note**
-> 
+>
 > Alternatively, if you haven’t navigated away from the job templates
 > creation page, you can scroll down to see all existing job templates
 

--- a/exercises/ansible_windows/6-roles/exercise6.md
+++ b/exercises/ansible_windows/6-roles/exercise6.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
--   [Agenda](index.html)
-
--   [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
--   [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
--   [Exercise 3 - Writing Your First playbook](exercise3.html)
-
--   [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
--   [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
--   [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
--   [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
--   [Wrap UP](wrapup.html)
-
 Although it is possible to write a playbook in one file as we’ve done
 throughout this workshop, eventually you’ll want to reuse files and
 start to organize things.

--- a/exercises/ansible_windows/7-win-patch/exercise7.md
+++ b/exercises/ansible_windows/7-win-patch/exercise7.md
@@ -1,24 +1,3 @@
-Table of Contents
-=================
-
--   [Agenda](index.html)
-
--   [Exercise 1 - Configuring Ansible Tower](exercise1.html)
-
--   [Exercise 2 - Ad-hoc commands in Tower](exercise2.html)
-
--   [Exercise 3 - Writing Your First playbook](exercise3.html)
-
--   [Exercise 4 - Creating and Running a Job Template](exercise4.html)
-
--   [Exercise 5 - Using Variables, Loops, and Handlers](exercise5.html)
-
--   [Exercise 6 - Roles: Making your playbooks reusable](exercise6.html)
-
--   [Exercise 7 - Using Ansible for Windows Patching](exercise7.html)
-
--   [Wrap UP](wrapup.html)
-
 Section 1 - Creating your Playbook
 ==================================
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Each exercise had html TOC at the top of the page leftover from the adoc to md conversion - removed
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
