### PR TITLE
Misspelling Line 222 - ios_config

### DIFF
--- a/exercises/ansible_network/2-first-playbook/README.md
+++ b/exercises/ansible_network/2-first-playbook/README.md
@@ -219,7 +219,7 @@ snmp-server community ansible-test RO
 
 # Takeaways
 
-- the **os_config** modules are idempotent, meaning they are stateful
+- the **ios_config** modules are idempotent, meaning they are stateful
 - **check mode** ensures the Ansible Playbook does not make any changes on the remote systems
 - **verbose mode** allows us to see more output to the terminal window, including which commands would be applied
 - This Ansible Playbook could be scheduled in **Red Hat Ansible Tower** to enforce the configuration.  For example this could mean the Ansible Playbook could be run once a day for a particular network.  In combination with **check mode** this could just be a read only Ansible Playbook that sees and reports if configuration is missing or modified on the network.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Line 222 contains misspelling of ios_config as os_config
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Misspelling of ios_config module in exercise document is typed as "os_config" on line 222 of 
workshops/exercises/ansible_network/2-first-playbook/README.md
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- the **os_config** modules are idempotent, meaning they are stateful
+ the **ios_config** modules are idempotent, meaning they are stateful
```
