### PR TITLE
make callback (role: tower_request) more robust for when Ansible Tower is unreachable or compromised 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->
+
 ##### SUMMARY
 <!--- Describe the change below, including rationale and design decisions -->
 

--- a/provisioner/group_vars/all.yml
+++ b/provisioner/group_vars/all.yml
@@ -5,6 +5,7 @@ teardown: false
 towerinstall: false
 website_information: ""
 dns_information: "No errors with DNS"
+callback_information: "No issue with Ansible Tower callback"
 workshop_type: ""
 dns_type: aws
 valid_dns_type:

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -224,6 +224,7 @@
           FAILURES
           *******************
           {{dns_information}}
+          {{callback_information}}
 
     - name: Print Summary Information
       debug:

--- a/provisioner/roles/tower_request/tasks/main.yml
+++ b/provisioner/roles/tower_request/tasks/main.yml
@@ -1,18 +1,31 @@
 ---
-- name: execute a command with tower
-  uri:
-    url: https://ansible.rhdemo.io/api/v2/job_templates/22/launch/
-    validate_certs: no
-    method: POST
-    user: public
-    password: public
-    status_code: [200, 201]
-    force_basic_auth: yes
-    body:
-      extra_vars:
-        ec2_name_prefix: "{{ ec2_name_prefix }}"
-        aws_user: "{{ aws_user }}"
-        ec2_region: "{{ ec2_region }}"
-        student_total: "{{ student_total }}"
-        workshop_type: "{{ workshop_type }}"
-    body_format: json
+- name: attempt callback to record data
+  block:
+    - name: execute a command with tower
+      uri:
+        url: https://ansible.rhdemo.io/api/v2/job_templates/22/launch/
+        validate_certs: no
+        method: POST
+        user: public
+        password: public
+        status_code: [200, 201]
+        force_basic_auth: yes
+        body:
+          extra_vars:
+            ec2_name_prefix: "{{ ec2_name_prefix }}"
+            aws_user: "{{ aws_user }}"
+            ec2_region: "{{ ec2_region }}"
+            student_total: "{{ student_total }}"
+            workshop_type: "{{ workshop_type }}"
+        body_format: json
+  rescue:
+    - debug:
+       msg: 'Ansible Tower callback has failed, we will fail gracefully'
+
+    - name: append information to summary
+      set_fact:
+        callback_information: |
+          - Ansible Tower callback failure, this workshop will not be recorded
+      run_once: yes
+      delegate_to: localhost
+      delegate_facts: true


### PR DESCRIPTION
##### SUMMARY
this pull request makes the callback (for information gathering purposes) more robust so that if the Ansible Tower server is down, the provisioner will fail gracefully with updated information

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
N/A
