### PR TITLE
fixing arista to use BYOL instance

### DIFF
--- a/provisioner/roles/manage_ec2_instances/defaults/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main.yml
@@ -44,6 +44,7 @@ ec2_info:
     ami: "{{arista_ami | default(omit)}}"
     os: eos
     username: ec2-user
+    filter: "*VEOSRouter*"
   checkpoint_mgmt:
     owners: 679593333241
     filter: 'Check Point CloudGuard IaaS BYOL*R80.30*'

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
@@ -20,14 +20,14 @@
 #### ARISTA AMI
 - name: BLOCK FOR ARISTA AMI
   block:
-  - name: find ami for arista (NETWORKING MODE)
-    ec2_ami_facts:
-      region: "{{ ec2_region }}"
-      owners: "679593333241"
-      filters:
-        name: "{{ec2_info.arista.filter}}"
-        architecture: "x86_64"
-    register: arista_amis
+    - name: find ami for arista (NETWORKING MODE)
+      ec2_ami_facts:
+        region: "{{ ec2_region }}"
+        owners: "679593333241"
+        filters:
+          name: "{{ec2_info.arista.filter}}"
+          architecture: "x86_64"
+      register: arista_amis
 
     - name: save ami for arista eos (NETWORKING MODE)
       set_fact:

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
@@ -20,14 +20,14 @@
 #### ARISTA AMI
 - name: BLOCK FOR ARISTA AMI
   block:
-    - name: find ami for arista (NETWORKING MODE)
-      ec2_ami_facts:
-        region: "{{ ec2_region }}"
-        owners: "679593333241"
-        filters:
-          name: "*EOS*"
-          architecture: "x86_64"
-      register: arista_amis
+  - name: find ami for arista (NETWORKING MODE)
+    ec2_ami_facts:
+      region: "{{ ec2_region }}"
+      owners: "679593333241"
+      filters:
+        name: "{{ec2_info.arista.filter}}"
+        architecture: "x86_64"
+    register: arista_amis
 
     - name: save ami for arista eos (NETWORKING MODE)
       set_fact:


### PR DESCRIPTION
### SUMMARY
seems like rate-limting is the only draw back which won't affect training for automation https://www.arista.com/en/cg-veos-router/veos-router-veos-licensing


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
trying to reduce costs for users doing the network automation workshop
