### PR TITLE
fixing routing configurations for cisco and arista

### DIFF
--- a/provisioner/networking.yml
+++ b/provisioner/networking.yml
@@ -36,10 +36,8 @@
     - role: configure_routers
       vars:
         type: access
-        router3_tunnel: 100
-        router4_tunnel: 101
       when:
-        - ansible_network_os == "ios"
+        - ansible_network_os == "ios" or ansible_network_os == "eos"
 
 - name: configure core routers
   hosts: core

--- a/provisioner/roles/configure_routers/tasks/main.yml
+++ b/provisioner/roles/configure_routers/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: APPLY ROUTER TEMPLATE
+- name: apply network device template
   vars:
     ansible_connection: network_cli
     ansible_become: true

--- a/provisioner/roles/configure_routers/templates/eos_access.j2
+++ b/provisioner/roles/configure_routers/templates/eos_access.j2
@@ -3,21 +3,20 @@
 hostname {{short_name}}
 !
 router ospf 1
- network 10.{{ site }}.{{ site }}.0 0.0.0.255 area 0
- network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} 0.0.0.255 area 0
- network {{ (private_ip ~ '/16') | ipaddr('network') }} 0.0.255.255 area 0
- network 192.168.{{ site }}.0 0.0.0.255 area 0
+ router-id 192.168.{{site}}.{{site}}
+ redistribute connected
 !
 interface Loopback0
- ip address 192.168.{{ site }}.10{{ site }} 255.255.255.0
-!
-interface Loopback1
- ip address 10.{{ site }}.{{ site }}.10{{ site }} 255.255.255.0
+ ip address 192.168.{{ site }}.{{ site }}/32
 !
 interface Tunnel0
+ ip mtu 1394
  ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
- ip mtu 1476
- tcp mss ceiling ipv4 1360
+ ip ospf network point-to-point
+ ip ospf area 0.0.0.0
+ tunnel mode gre
  tunnel source interface Ethernet1
  tunnel destination {{ device[short_name].ospf_tunnel_destination }}
+ tunnel path-mtu-discovery
+ tunnel ttl 10
 !

--- a/provisioner/roles/configure_routers/templates/eos_access.j2
+++ b/provisioner/roles/configure_routers/templates/eos_access.j2
@@ -1,0 +1,23 @@
+{% set site = device[short_name].site %}
+!
+hostname {{short_name}}
+!
+router ospf 1
+ network 10.{{ site }}.{{ site }}.0 0.0.0.255 area 0
+ network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} 0.0.0.255 area 0
+ network {{ (private_ip ~ '/16') | ipaddr('network') }} 0.0.255.255 area 0
+ network 192.168.{{ site }}.0 0.0.0.255 area 0
+!
+interface Loopback0
+ ip address 192.168.{{ site }}.10{{ site }} 255.255.255.0
+!
+interface Loopback1
+ ip address 10.{{ site }}.{{ site }}.10{{ site }} 255.255.255.0
+!
+interface Tunnel0
+ ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip mtu 1476
+ tcp mss ceiling ipv4 1360
+ tunnel source interface Ethernet1
+ tunnel destination {{ device[short_name].ospf_tunnel_destination }}
+!

--- a/provisioner/roles/configure_routers/templates/eos_core.j2
+++ b/provisioner/roles/configure_routers/templates/eos_core.j2
@@ -3,24 +3,22 @@
 hostname {{short_name}}
 !
 router ospf 1
+ router-id 192.168.{{site}}.{{site}}
  redistribute bgp
- network 10.{{ site }}.{{ site }}.0 0.0.0.255 area 0
- network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} 0.0.0.255 area 0
- network {{ (private_ip ~ '/16') | ipaddr('network') }} 0.0.255.255 area 0
- network 192.168.{{ site }}.0 0.0.0.255 area 0
 !
 interface Loopback0
- ip address 192.168.{{ site }}.10{{ site }} 255.255.255.0
-!
-interface Loopback1
- ip address 10.{{ site }}.{{ site }}.10{{ site }} 255.255.255.0
+ ip address 192.168.{{ site }}.{{ site }}/32
 !
 interface Tunnel0
+ ip mtu 1394
  ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
- ip mtu 1476
- tcp mss ceiling ipv4 1360
+ ip ospf network point-to-point
+ ip ospf area 0.0.0.0
+ tunnel mode gre
  tunnel source interface Ethernet1
  tunnel destination {{ device[short_name].ospf_tunnel_destination }}
+ tunnel path-mtu-discovery
+ tunnel ttl 10
 !
 interface Tunnel1
  ip address {{ device[short_name].bgp_tunnel_source }} 255.255.255.0
@@ -28,17 +26,16 @@ interface Tunnel1
  tunnel destination {{ device[short_name].bgp_tunnel_destination }}
 !
 !
+{% set neighbor = device[short_name].bgp_neighbor %}
 router bgp {{ device[short_name].local_as }}
- router-id {{ site }}.{{ site }}.{{ site }}.{{ site }}
+ router-id 192.168.{{ site }}.{{ site }}
  bgp log-neighbor-changes
- neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} remote-as {{ device[device[short_name].bgp_neighbor].local_as }}
- neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} ebgp-multihop 255
+ neighbor {{ device[neighbor].bgp_tunnel_source }} remote-as {{ device[neighbor].local_as }}
+ neighbor {{ device[neighbor].bgp_tunnel_source }} ebgp-multihop 255
 !
  address-family ipv4
-  network 10.{{site}}.{{site}}.0 mask 255.255.255.0
-  network {{  device[short_name].remote_ospf_neighbor }} mask 255.255.255.255
+  neighbor {{ device[neighbor].bgp_tunnel_source }} activate
+  network 192.168.{{site}}.{{site}} mask 255.255.255.255
   network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} mask 255.255.255.0
   network 10.200.200.0 mask 255.255.255.0
   network {{ (private_ip ~ '/16') | ipaddr('network') }}/16
-  network 192.168.{{ site }}.0/24
-  neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} activate

--- a/provisioner/roles/configure_routers/templates/ios_access.j2
+++ b/provisioner/roles/configure_routers/templates/ios_access.j2
@@ -3,20 +3,17 @@
 hostname {{short_name}}
 
 router ospf 1
- network 10.{{ site }}.{{ site }}.0 0.0.0.255 area 0
- network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} 0.0.0.255 area 0
- network {{ (private_ip ~ '/16') | ipaddr('network') }} 0.0.255.255 area 0
- network 192.168.{{ site }}.0 0.0.0.255 area 0
+ router-id 192.168.{{site}}.{{site}}
+ redistribute connected
 
 interface Loopback0
- ip address 192.168.{{ site }}.10{{ site }} 255.255.255.0
-
-interface Loopback1
- ip address 10.{{ site }}.{{ site }}.10{{ site }} 255.255.255.0
+ ip address 192.168.{{ site }}.{{ site }} 255.255.255.255
 
 interface Tunnel0
- ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
  ip mtu 1476
+ ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip ospf network point-to-point
+ ip ospf area 0.0.0.0
  ip tcp adjust-mss 1360
  tunnel source GigabitEthernet1
  tunnel destination {{ device[short_name].ospf_tunnel_destination }}

--- a/provisioner/roles/configure_routers/templates/ios_core.j2
+++ b/provisioner/roles/configure_routers/templates/ios_core.j2
@@ -3,17 +3,11 @@
 hostname {{short_name}}
 !
 router ospf 1
+ router-id 192.168.{{site}}.{{site}}
  redistribute bgp {{ device[short_name].local_as }} subnets
- network 10.{{ site }}.{{ site }}.0 0.0.0.255 area 0
- network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} 0.0.0.255 area 0
- network {{ (private_ip ~ '/16') | ipaddr('network') }} 0.0.255.255 area 0
- network 192.168.{{ site }}.0 0.0.0.255 area 0
 !
 interface Loopback0
- ip address 192.168.{{ site }}.10{{ site }} 255.255.255.0
-!
-interface Loopback1
- ip address 10.{{ site }}.{{ site }}.10{{ site }} 255.255.255.0
+ ip address 192.168.{{ site }}.{{ site }} 255.255.255.255
 !
 interface Tunnel0
  ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
@@ -27,19 +21,17 @@ interface Tunnel1
  tunnel source GigabitEthernet1
  tunnel destination {{ device[short_name].bgp_tunnel_destination }}
 !
-!
+{% set neighbor = device[short_name].bgp_neighbor %}
 router bgp {{ device[short_name].local_as }}
- bgp router-id {{ site }}.{{ site }}.{{ site }}.{{ site }}
+ bgp router-id 192.168.{{site}}.{{site}}
  bgp log-neighbor-changes
- neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} remote-as {{ device[device[short_name].bgp_neighbor].local_as }}
- neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} ebgp-multihop 255
+ neighbor {{ device[neighbor].bgp_tunnel_source }} remote-as {{ device[neighbor].local_as }}
+ neighbor {{ device[neighbor].bgp_tunnel_source }} ebgp-multihop 255
 !
  address-family ipv4
-  network 10.{{site}}.{{site}}.0 mask 255.255.255.0
-  network {{  device[short_name].remote_ospf_neighbor }} mask 255.255.255.255
+  neighbor {{ device[neighbor].bgp_tunnel_source }} activate
+  network 192.168.{{site}}.{{site}} mask 255.255.255.255
   network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} mask 255.255.255.0
   network 10.200.200.0 mask 255.255.255.0
   network {{ (private_ip ~ '/16') | ipaddr('network') }}
-  network 192.168.{{ site }}.0
-  neighbor {{ device[device[short_name].bgp_neighbor].bgp_tunnel_source }} activate
  exit-address-family

--- a/provisioner/roles/configure_routers/vars/main.yml
+++ b/provisioner/roles/configure_routers/vars/main.yml
@@ -24,5 +24,5 @@ device:
     ospf_tunnel_destination: "{{ rtr1_node_facts.instances[0].public_ip_address }}"
   rtr4:
     site: 4
-    ospf_tunnel_source: "10.101.101.2"
+    ospf_tunnel_source: "10.101.101.4"
     ospf_tunnel_destination: "{{ rtr2_node_facts.instances[0].public_ip_address }}"


### PR DESCRIPTION
##### SUMMARY
simplifying and fixing the router configurations for cisco and arista so that ospf and bgp come up in an only cisco or only arista environment .

TODO: add juniper

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
n/a
