### PR TITLE
add juniper OSPF connection for network automation lab

### DIFF
--- a/provisioner/networking.yml
+++ b/provisioner/networking.yml
@@ -36,8 +36,6 @@
     - role: configure_routers
       vars:
         type: access
-      when:
-        - ansible_network_os == "ios" or ansible_network_os == "eos"
 
 - name: configure core routers
   hosts: core

--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -9,21 +9,36 @@
       - py_cmd.stdout is version('1.7', operator='ge')
     msg: "boto3 >= 1.7 is required."
 
-- name: check for underscores in workshop name
-  fail:
-    msg: "Amazon AWS does not allow underscores _ for s3 websites, please see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"
+- name: check route53 information
+  block:
+    - name: check for underscores in workshop name
+      fail:
+        msg: "Amazon AWS does not allow underscores _ for s3 websites, please see https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html"
+      when:
+        - "'_' in ec2_name_prefix"
+
+    - name: does route53 zone exist
+      check_mode: true
+      route53_zone:
+        zone: "{{workshop_dns_zone}}"
+        state: present
+      register: test
+
+    - name: make sure workshop_type is set to a correct value
+      assert:
+        that:
+          - test.zone_id is not none
+        msg:
+          - "You must have a valid route53 zone configured for workshop_dns_zone"
+          - "Right now the workshop_dns_zone is {{workshop_dns_zone}}"
   when:
     - create_login_page is defined
     - create_login_page|bool
-    - "'_' in ec2_name_prefix"
 
 - name: FIND AZ ZONE FOR REGION {{ec2_region}}
   aws_az_facts:
     region: "{{ec2_region}}"
   register: az_names
-
-# - debug:
-#     var: az_names
 
 - name: SET AZ ZONE TO FIRST AVAILABLE
   set_fact: ec2_az={{az_names.availability_zones[0].zone_name}}
@@ -36,5 +51,3 @@
 - name: save username of AWS user
   set_fact:
     aws_user: '{{ whoami.arn.split("/")[-1] }}'
-
-- debug: msg='{{ whoami.arn.split("/")[-1] }}'

--- a/provisioner/roles/configure_routers/templates/eos_access.j2
+++ b/provisioner/roles/configure_routers/templates/eos_access.j2
@@ -11,7 +11,7 @@ interface Loopback0
 !
 interface Tunnel0
  ip mtu 1394
- ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].ospf_tunnel_ip }} 255.255.255.0
  ip ospf network point-to-point
  ip ospf area 0.0.0.0
  tunnel mode gre

--- a/provisioner/roles/configure_routers/templates/eos_core.j2
+++ b/provisioner/roles/configure_routers/templates/eos_core.j2
@@ -11,7 +11,7 @@ interface Loopback0
 !
 interface Tunnel0
  ip mtu 1394
- ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].ospf_tunnel_ip }} 255.255.255.0
  ip ospf network point-to-point
  ip ospf area 0.0.0.0
  tunnel mode gre
@@ -21,7 +21,7 @@ interface Tunnel0
  tunnel ttl 10
 !
 interface Tunnel1
- ip address {{ device[short_name].bgp_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].bgp_tunnel_ip }} 255.255.255.0
  tunnel source interface Ethernet1
  tunnel destination {{ device[short_name].bgp_tunnel_destination }}
 !
@@ -30,12 +30,13 @@ interface Tunnel1
 router bgp {{ device[short_name].local_as }}
  router-id 192.168.{{ site }}.{{ site }}
  bgp log-neighbor-changes
- neighbor {{ device[neighbor].bgp_tunnel_source }} remote-as {{ device[neighbor].local_as }}
- neighbor {{ device[neighbor].bgp_tunnel_source }} ebgp-multihop 255
+ neighbor {{ device[neighbor].bgp_tunnel_ip }} remote-as {{ device[neighbor].local_as }}
+ neighbor {{ device[neighbor].bgp_tunnel_ip }} ebgp-multihop 255
+ redistribute ospf match external
 !
  address-family ipv4
-  neighbor {{ device[neighbor].bgp_tunnel_source }} activate
+  neighbor {{ device[neighbor].bgp_tunnel_ip }} activate
   network 192.168.{{site}}.{{site}} mask 255.255.255.255
-  network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} mask 255.255.255.0
+  network {{ (device[short_name].ospf_tunnel_ip ~ '/24') | ipaddr('network') }} mask 255.255.255.0
   network 10.200.200.0 mask 255.255.255.0
   network {{ (private_ip ~ '/16') | ipaddr('network') }}/16

--- a/provisioner/roles/configure_routers/templates/ios_access.j2
+++ b/provisioner/roles/configure_routers/templates/ios_access.j2
@@ -11,7 +11,7 @@ interface Loopback0
 
 interface Tunnel0
  ip mtu 1476
- ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].ospf_tunnel_ip }} 255.255.255.0
  ip ospf network point-to-point
  ip ospf area 0.0.0.0
  ip tcp adjust-mss 1360

--- a/provisioner/roles/configure_routers/templates/ios_core.j2
+++ b/provisioner/roles/configure_routers/templates/ios_core.j2
@@ -10,14 +10,15 @@ interface Loopback0
  ip address 192.168.{{ site }}.{{ site }} 255.255.255.255
 !
 interface Tunnel0
- ip address {{ device[short_name].ospf_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].ospf_tunnel_ip }} 255.255.255.0
  ip mtu 1476
  ip tcp adjust-mss 1360
+ ip ospf 1 area 0
  tunnel source GigabitEthernet1
  tunnel destination {{ device[short_name].ospf_tunnel_destination }}
 !
 interface Tunnel1
- ip address {{ device[short_name].bgp_tunnel_source }} 255.255.255.0
+ ip address {{ device[short_name].bgp_tunnel_ip }} 255.255.255.0
  tunnel source GigabitEthernet1
  tunnel destination {{ device[short_name].bgp_tunnel_destination }}
 !
@@ -25,13 +26,14 @@ interface Tunnel1
 router bgp {{ device[short_name].local_as }}
  bgp router-id 192.168.{{site}}.{{site}}
  bgp log-neighbor-changes
- neighbor {{ device[neighbor].bgp_tunnel_source }} remote-as {{ device[neighbor].local_as }}
- neighbor {{ device[neighbor].bgp_tunnel_source }} ebgp-multihop 255
+ neighbor {{ device[neighbor].bgp_tunnel_ip }} remote-as {{ device[neighbor].local_as }}
+ neighbor {{ device[neighbor].bgp_tunnel_ip }} ebgp-multihop 255
 !
  address-family ipv4
-  neighbor {{ device[neighbor].bgp_tunnel_source }} activate
+  redistribute ospf 1
+  neighbor {{ device[neighbor].bgp_tunnel_ip }} activate
   network 192.168.{{site}}.{{site}} mask 255.255.255.255
-  network {{ (device[short_name].ospf_tunnel_source ~ '/24') | ipaddr('network') }} mask 255.255.255.0
+  network {{ (device[short_name].ospf_tunnel_ip ~ '/24') | ipaddr('network') }} mask 255.255.255.0
   network 10.200.200.0 mask 255.255.255.0
   network {{ (private_ip ~ '/16') | ipaddr('network') }}
  exit-address-family

--- a/provisioner/roles/configure_routers/templates/junos_access.j2
+++ b/provisioner/roles/configure_routers/templates/junos_access.j2
@@ -1,0 +1,8 @@
+{% set site = device[short_name].site %}
+set system host-name {{short_name}}
+set interfaces lo0 unit 0 family inet address 192.168.{{site}}.{{site}}
+set interfaces gr-0/0/0 unit 0 tunnel source {{ device[short_name].ospf_tunnel_source}}
+set interfaces gr-0/0/0 unit 0 tunnel destination {{ device[short_name].ospf_tunnel_destination }}
+set interfaces gr-0/0/0 unit 0 family inet address {{ device[short_name].ospf_tunnel_ip }}/24
+set protocols ospf area 0.0.0.0 interface gr-0/0/0
+set protocols ospf area 0.0.0.0 interface lo0 passive

--- a/provisioner/roles/configure_routers/vars/main.yml
+++ b/provisioner/roles/configure_routers/vars/main.yml
@@ -3,26 +3,28 @@ device:
   rtr1:
     site: 1
     local_as: 65000
-    bgp_tunnel_source: "10.200.200.1"
+    bgp_tunnel_ip: "10.200.200.1"
     bgp_tunnel_destination: "{{ rtr2_node_facts.instances[0].public_ip_address }}"
     bgp_neighbor: "rtr2"
-    remote_ospf_neighbor: "10.3.3.103"
-    ospf_tunnel_source: "10.100.100.1"
-    ospf_tunnel_destination: "{{ rtr3_node_facts.instances[0].public_ip_address }}"
+    ospf_tunnel_ip: "10.100.100.1"
+    ospf_tunnel_destination: "{{ rtr3_node_facts.instances[0].private_ip_address }}"
+    ospf_tunnel_source: "{{ rtr1_node_facts.instances[0].private_ip_address }}"
   rtr2:
     site: 2
     local_as: 65001
-    bgp_tunnel_source: "10.200.200.2"
+    bgp_tunnel_ip: "10.200.200.2"
     bgp_tunnel_destination: "{{ rtr1_node_facts.instances[0].public_ip_address }}"
     bgp_neighbor: "rtr1"
-    remote_ospf_neighbor: "10.4.4.104"
-    ospf_tunnel_source: "10.101.101.2"
-    ospf_tunnel_destination: "{{ rtr4_node_facts.instances[0].public_ip_address }}"
+    ospf_tunnel_ip: "10.101.101.2"
+    ospf_tunnel_destination: "{{ rtr4_node_facts.instances[0].private_ip_address }}"
+    ospf_tunnel_source: "{{ rtr2_node_facts.instances[0].private_ip_address }}"
   rtr3:
     site: 3
-    ospf_tunnel_source: "10.100.100.2"
-    ospf_tunnel_destination: "{{ rtr1_node_facts.instances[0].public_ip_address }}"
+    ospf_tunnel_ip: "10.100.100.2"
+    ospf_tunnel_destination: "{{ rtr1_node_facts.instances[0].private_ip_address }}"
+    ospf_tunnel_source: "{{ rtr3_node_facts.instances[0].private_ip_address }}"
   rtr4:
     site: 4
-    ospf_tunnel_source: "10.101.101.4"
-    ospf_tunnel_destination: "{{ rtr2_node_facts.instances[0].public_ip_address }}"
+    ospf_tunnel_ip: "10.101.101.4"
+    ospf_tunnel_destination: "{{ rtr2_node_facts.instances[0].private_ip_address }}"
+    ospf_tunnel_source: "{{ rtr4_node_facts.instances[0].private_ip_address }}"

--- a/provisioner/roles/control_node/templates/ansible.cfg.j2
+++ b/provisioner/roles/control_node/templates/ansible.cfg.j2
@@ -7,11 +7,11 @@ host_key_checking = False
 retry_files_enabled = False
 {% if (workshop_type == 'rhel') or (workshop_type == 'security') %}
 inventory = /home/{{username}}/lab_inventory/hosts
-{% elif workshop_type == 'devops' %}  
+{% elif workshop_type == 'devops' %}
 inventory = /home/{{username}}/devops-workshop/lab_inventory/hosts
 {% else %}
 inventory = /home/{{username}}/networking-workshop/lab_inventory/hosts
 [persistent_connection]
-connect_timeout = 300
-command_timeout = 300
+connect_timeout = 200
+command_timeout = 200
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
see title, this will allow a OSPF connection between a cisco ios router and a juniper router for the default network_type, for the network automation workshop

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
this also fixes some other issues such as 
- https://github.com/ansible/workshops/issues/339
- https://github.com/ansible/workshops/issues/529