### PR TITLE
fixing bug 449

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -49,6 +49,18 @@
       assert:
         that:
           - ec2_name_prefix != "TESTWORKSHOP"
+        msg:
+          - "ec2_name_prefix cannot be set to TESTWORKSHOP"
+          - "please set a unique name for your workshop"
+
+
+    - name: make sure we are not using `ansible` as the password
+      assert:
+        that:
+          - admin_password != "ansible"
+        msg:
+          - "admin_password cannot be set to ansible"
+          - "please set a unique password for your workshop"
 
     - name: make sure packages required are installed on this control node
       pip:

--- a/provisioner/tests/gating.groovy
+++ b/provisioner/tests/gating.groovy
@@ -215,6 +215,7 @@ EOF
                                              "ANSIBLE_FORCE_COLOR=true"]) {
                                         sh """ansible-playbook provisioner/provision_lab.yml \
                                                 -e @provisioner/tests/vars.yml \
+                                                -e @provisioner/tests/ci-common.yml \
                                                 -e @provisioner/tests/ci-security.yml"""
                                     }
                                 }

--- a/provisioner/tests/pipeline.groovy
+++ b/provisioner/tests/pipeline.groovy
@@ -264,6 +264,7 @@ EOF
                                              "ANSIBLE_FORCE_COLOR=true"]) {
                                         sh '''ansible-playbook provisioner/provision_lab.yml \
                                                 -e @provisioner/tests/vars.yml \
+                                                -e @provisioner/tests/ci-common.yml \
                                                 -e @provisioner/tests/ci-security.yml 2>&1 | tee security.log && exit ${PIPESTATUS[0]}'''
                                     }
                                 }


### PR DESCRIPTION
##### SUMMARY
fixing bug https://github.com/ansible/workshops/issues/449

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
will now have an error like this->
```
TASK [make sure we are not using `ansible` as the password] *********************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  assertion: admin_password != "ansible"
  evaluated_to: false
  msg:
  - admin_password cannot be set to ansible
  - please set a unique password for your workshop
```
