### PR TITLE
security - don't search for old outdated AMIs for Windows

### DIFF
--- a/provisioner/roles/manage_ec2_instances/defaults/main.yml
+++ b/provisioner/roles/manage_ec2_instances/defaults/main.yml
@@ -61,7 +61,7 @@ ec2_info:
     username: admin
   windows_ws:
     owners: 679593333241
-    filter: 'Windows_Server-2016-English-Full-Base-2019.08.16'
+    filter: 'Windows_Server-2016-English-Full-Base*'
     size: m5.xlarge
     ami: "{{ windows_ws_ami| default(omit) }}"
     username: Administrator


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Don't search for old outdated AMIs for Windows in Security Workshop
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner



