### PR TITLE
add https (ssl) support to vs code (code server) for web browser access

### DIFF
--- a/provisioner/group_vars/all.yml
+++ b/provisioner/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 admin_password: ansible
+code_server: true
 workshop_dns_zone: "rhdemo.io"
 s3_state: "present"
 teardown: false
@@ -7,6 +8,7 @@ towerinstall: false
 website_information: ""
 dns_information: "No errors with DNS"
 callback_information: "No issue with Ansible Tower callback"
+coder_information: "No issue with VS code integration"
 workshop_type: ""
 dns_type: aws
 valid_dns_type:

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -184,15 +184,14 @@
     - common
   tags: control_node
 
-
 - name: CONFIGURE CONTROL NODE
   hosts: control_nodes
   gather_facts: true
   become: true
   roles:
     - control_node
+    - code_server
   tags: control_node
-
 
 - name: add dns entires for all student control nodes
   hosts: control_nodes
@@ -248,6 +247,7 @@
           *******************
           {{dns_information}}
           {{callback_information}}
+          {{coder_information}}
 
     - name: Print Summary Information
       debug:

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -33,6 +33,14 @@
         msg: "network_type must be defined and be one of: {{valid_network_types}}"
       when: workshop_type == "networking"
 
+    - name: make sure DNS name is 65 characters or less
+      vars:
+        test_name: "studentXXX-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+      assert:
+        that:
+          - "{{test_name|length}} <= 65"
+        msg: "you must make sure your DNS name is shorter"
+
     - name: make sure security_console is set to a correct value
       assert:
         that:
@@ -189,8 +197,11 @@
   gather_facts: true
   become: true
   roles:
-    - control_node
-    - code_server
+    - role: control_node
+    - role: code_server
+      when:
+        - code_server is defined
+        - code_server
   tags: control_node
 
 - name: add dns entires for all student control nodes

--- a/provisioner/roles/aws_dns/tasks/main.yml
+++ b/provisioner/roles/aws_dns/tasks/main.yml
@@ -8,7 +8,7 @@
     url: "https://{{username}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}/api/v2/ping/"
     method: GET
     user: admin
-    password: ansible
+    password: "{{admin_password}}"
     validate_certs: true
     force_basic_auth: true
   register: check_cert

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -11,10 +11,14 @@
   width: 400px;
 }
 
+#section_title {
+  font-weight: bold;
+  font-size: 25px;
+}
+
 #example_login {
   padding-top: 5px;
 }
-
 
 hr {
   width: 80%;
@@ -375,7 +379,23 @@ $("document").ready(function(){
     <div class="content">
 {% for host in ansible_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-To login to the ansible control node use the following for SSH access:<br>
+{% if code_server %}
+<div id="section_title">VS Code access</div>
+To login to Visual Studio Code via your web browser please go here:<br>
+<table>
+  <tr>
+    <td>UI link:</td>
+    <td><a href="https://student{{number}}-code.{{ec2_name_prefix}}.{{workshop_dns_zone}}">https://student{{number}}-code.{{ec2_name_prefix}}.{{workshop_dns_zone}}</a></td>
+  </tr>
+  <tr>
+    <td>password:</td>
+    <td><code>{{admin_password}}</code></td>
+  </tr>
+</table><br>
+<hr>
+{% endif %}
+<div id="section_title">SSH access</div>
+To login to the Ansible Control Node use the following for SSH access:<br>
 <div id="control_node">
 <div id="login_info">
 <table>
@@ -404,16 +424,9 @@ DNS: student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
 <div id="tower_info">
 <hr>
 {% if towerinstall %}
+<div id="section_title">Ansible Tower Access</div>
 To login to the Ansible Tower UI use the following credentials:<br>
 <table>
-  <tr>
-    <td>username:</td>
-    <td><code>admin</code></td>
-  </tr>
-  <tr>
-    <td>password:</td>
-    <td><code>{{admin_password}}</code></td>
-  </tr>
 {% if dns_type != 'none' %}
   <tr>
 <td>UI link:</td>
@@ -426,6 +439,14 @@ To login to the Ansible Tower UI use the following credentials:<br>
 <td><a href="https://{{ host.public_ip_address }}">https://{{ host.public_ip_address }}</a></td>
   </tr>
 {% endif %}
+  <tr>
+    <td>username:</td>
+    <td><code>admin</code></td>
+  </tr>
+  <tr>
+    <td>password:</td>
+    <td><code>{{admin_password}}</code></td>
+  </tr>
 </table>
 {% endif %}
 </div>

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -1,0 +1,104 @@
+---
+- name: install cerbot
+  yum:
+    name: certbot
+
+- name: turn off tower
+  shell: ansible-tower-service stop
+
+- name: dns for coder
+  become: false
+  route53:
+    state: "{{ s3_state }}"
+    zone: "{{workshop_dns_zone}}"
+    record: "{{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    type: A
+    overwrite: true
+    value: "{{ansible_host}}"
+  delegate_to: localhost
+  register: route53_status
+
+- name: grab latest release of Coder binary
+  uri:
+    url: https://api.github.com/repos/cdr/code-server/releases/latest
+  register: github_result
+
+- name: save url for extraction of Coder binary
+  set_fact:
+    download_url: "{{item.browser_download_url}}"
+    version_name: "{{item.name.split('.tar')[0]}}"
+  when: "'linux' in item.browser_download_url"
+  loop: "{{github_result.json.assets}}"
+  loop_control:
+    label: "{{ item.browser_download_url }}"
+
+- name: Extract file
+  unarchive:
+    src: "{{download_url}}"
+    dest: "/home/{{username}}"
+    remote_src: true
+  register: output
+
+- name: install ansible vscode extension
+  command: "/home/{{username}}/{{ version_name }}/code-server --install-extension vscoss.vscode-ansible"
+
+- name: move binary to /opt
+  copy:
+    src: /home/{{username}}/{{ version_name }}/code-server
+    dest: /opt/code-server
+    remote_src: true
+    mode: '0744'
+    owner: "{{username}}"
+    group: "{{username}}"
+
+- name: update nginx configuration to support code server
+  blockinfile:
+    block: "{{ lookup('template', 'nginx.conf') }}"
+    dest: /etc/nginx/nginx.conf
+    insertafter: "http {"
+
+- name: Apply systemd service file
+  template:
+    src: code-server.service.j2
+    dest: /etc/systemd/system/code-server.service
+    owner: "{{username}}"
+    group: wheel
+    mode: '0744'
+
+# source: https://vscode.readthedocs.io/en/latest/getstarted/settings/
+- name: ensure custom facts directory exists
+  file:
+    path: "/home/{{username}}/.local/share/code-server/User/"
+    recurse: yes
+    state: directory
+    owner: "{{username}}"
+
+- name: apply code server defaults
+  template:
+    src: settings.json
+    dest: "/home/{{username}}/.local/share/code-server/User/settings.json"
+    owner: "{{username}}"
+
+- name: start code-server service
+  service:
+    name: code-server
+    state: started
+    enabled: true
+
+- name: issue cert
+  shell: certbot certonly --standalone -d {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
+  register: issue_cert
+  until: issue_cert is not failed
+  retries: 5
+  ignore_errors: true
+
+- name: turn on tower
+  shell: ansible-tower-service start
+  register: install_tower
+  until: install_tower is not failed
+  retries: 5
+
+- name: cleanup Coder binary from student directory
+  file:
+    path: /home/{{username}}/{{ version_name }}
+    state: absent

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -69,7 +69,7 @@
 - name: ensure custom facts directory exists
   file:
     path: "/home/{{username}}/.local/share/code-server/User/"
-    recurse: yes
+    recurse: true
     state: directory
     owner: "{{username}}"
 

--- a/provisioner/roles/code_server/tasks/main.yml
+++ b/provisioner/roles/code_server/tasks/main.yml
@@ -4,7 +4,7 @@
   when: teardown|bool
 
 - name: check to see if SSL cert already applied
-  become: no
+  become: false
   get_certificate:
     host: "{{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
     port: 443

--- a/provisioner/roles/code_server/tasks/main.yml
+++ b/provisioner/roles/code_server/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: remove dns entries for each vs code instance
+  include_tasks: teardown.yml
+  when: teardown|bool
+
+- name: check to see if SSL cert already applied
+  become: no
+  get_certificate:
+    host: "{{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    port: 443
+  delegate_to: localhost
+  run_once: true
+  register: check_cert
+  ignore_errors: true
+  when:
+    - not teardown
+
+- name: perform DNS and SSL certs for ansible control node
+  block:
+    - name: setup vscode for web browser access
+      include_tasks: "codeserver.yml"
+  rescue:
+    - debug:
+        msg: 'VS code integration has failed'
+
+    - name: make sure tower is on
+      shell: ansible-tower-service start
+      register: install_tower
+      until: install_tower is not failed
+      retries: 5
+
+    - name: appends
+      set_fact:
+        coder_information: |
+          - VS code integration has failed, please use direct SSH addresses
+      run_once: true
+      delegate_to: localhost
+      delegate_facts: true
+  when:
+    - not teardown|bool
+    - check_cert is failed

--- a/provisioner/roles/code_server/tasks/main.yml
+++ b/provisioner/roles/code_server/tasks/main.yml
@@ -23,6 +23,13 @@
     - debug:
         msg: 'VS code integration has failed'
 
+    - name: remove additional nginx configuration because of failure
+      blockinfile:
+        block: "{{ lookup('template', 'nginx.conf') }}"
+        dest: /etc/nginx/nginx.conf
+        state: absent
+        insertafter: "http {"
+
     - name: make sure tower is on
       shell: ansible-tower-service start
       register: install_tower
@@ -33,6 +40,7 @@
       set_fact:
         coder_information: |
           - VS code integration has failed, please use direct SSH addresses
+        code_server: false
       run_once: true
       delegate_to: localhost
       delegate_facts: true

--- a/provisioner/roles/code_server/tasks/teardown.yml
+++ b/provisioner/roles/code_server/tasks/teardown.yml
@@ -1,0 +1,27 @@
+---
+- name: GRAB ZONE ID
+  route53_zone:
+    zone: "{{workshop_dns_zone}}"
+  register: AWSINFO
+
+- name: GRAB ROUTE53 INFORMATION
+  route53_facts:
+    type: A
+    query: record_sets
+    hosted_zone_id: "{{AWSINFO.zone_id}}"
+    start_record_name: "student1-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    max_items: "{% if ansible_version.minor <= 9 %}{{student_total|string}}{% else %}{{student_total|int}}{% endif %}"
+  register: record_sets
+
+- name: delete dns entries for vs code for each student
+  become: false
+  route53:
+    state: "{{ s3_state }}"
+    zone: "{{workshop_dns_zone}}"
+    record: "student{{item}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}"
+    type: A
+    value: "{{ (records | first | first)['Value'] }}"
+  loop: "{{ range(1, student_total + 1)|list }}"
+  vars:
+    records: '{{record_sets.ResourceRecordSets | selectattr("Name", "match", "student" + item|string + "-code." + ec2_name_prefix|lower + "." + workshop_dns_zone) | map(attribute="ResourceRecords") | list }}'
+  when: records | length > 0

--- a/provisioner/roles/code_server/templates/code-server.service.j2
+++ b/provisioner/roles/code_server/templates/code-server.service.j2
@@ -8,10 +8,10 @@ User={{username}}
 WorkingDirectory=/home/{{username}}
 Restart=on-failure
 RestartSec=10
-Environment="PASSWORD={{ admin_password }}"
+Environment="PASSWORD={{admin_password}}"
 
-ExecStart=/opt/code-server /home/{{username}}
-
+ExecStart=/opt/code-server --cert $(pwd)
+ExecStop=/bin/kill -s QUIT $MAINPID
 StandardOutput=file:/var/log/code-server-output.log
 StandardError=file:/var/log/code-server-error.log
 

--- a/provisioner/roles/code_server/templates/nginx.conf
+++ b/provisioner/roles/code_server/templates/nginx.conf
@@ -1,0 +1,21 @@
+    server {
+        listen 80;
+        listen [::]:80;
+        listen 443;
+        listen [::]:443;
+        server_name {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}};
+      location / {
+          proxy_pass https://127.0.0.1:8080;
+          proxy_set_header Host $host;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection upgrade;
+          proxy_set_header Accept-Encoding gzip;
+      }
+
+        # Protect against click-jacking https://www.owasp.org/index.php/Testing_for_Clickjacking_(OTG-CLIENT-009)
+        add_header X-Frame-Options "DENY";
+
+        location /favicon.ico { alias /var/lib/awx/public/static/favicon.ico; }
+        ssl_certificate /etc/letsencrypt/live/{{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/{{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}/privkey.pem;
+    }

--- a/provisioner/roles/code_server/templates/nginx.conf
+++ b/provisioner/roles/code_server/templates/nginx.conf
@@ -1,3 +1,4 @@
+    server_names_hash_bucket_size 256;
     server {
         listen 80;
         listen [::]:80;

--- a/provisioner/roles/code_server/templates/settings.json
+++ b/provisioner/roles/code_server/templates/settings.json
@@ -1,0 +1,4 @@
+{
+    "git.ignoreLegacyWarning": true,
+    "terminal.integrated.experimentalRefreshOnResume": true
+}

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -38,59 +38,6 @@
     owner: "{{ username }}"
     group: "{{ username }}"
 
-- name: Get latest release of Coder binary
-  uri:
-    url: https://api.github.com/repos/cdr/code-server/releases/latest
-  register: github_result
-
-- name: Save url for extraction of Coder binary
-  set_fact:
-    download_url: "{{item.browser_download_url}}"
-    version_name: "{{item.name.split('.tar')[0]}}"
-  when: "'linux' in item.browser_download_url"
-  loop: "{{github_result.json.assets}}"
-  loop_control:
-    label: "{{ item.browser_download_url }}"
-
-- name: Extract file
-  unarchive:
-    src: "{{download_url}}"
-    dest: "/home/{{username}}"
-    remote_src: true
-  register: output
-
-- name: Install ansible vscode extension
-  command: "/home/{{username}}/{{ version_name }}/code-server --auth none --install-extension vscoss.vscode-ansible"
-  register: result
-
-- name: Move binary to /opt
-  copy:
-    src: /home/{{username}}/{{ version_name }}/code-server
-    dest: /opt/code-server
-    remote_src: true
-    mode: '0744'
-    owner: "{{username}}"
-    group: "{{username}}"
-
-- name: Apply systemd service file
-  template:
-    src: code-server.service.j2
-    dest: /etc/systemd/system/code-server.service
-    owner: "{{username}}"
-    group: wheel
-    mode: '0744'
-
-- name: Start code-server service
-  service:
-    name: code-server
-    state: started
-    enabled: true
-
-- name: Cleanup Coder binary from student directory
-  file:
-    path: /home/{{username}}/{{ version_name }}
-    state: absent
-
 - name: setup control node networking
   include_tasks: "networking.yml"
   when: workshop_type in ['networking', 'f5']

--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -16,6 +16,7 @@
     - {include_role: {name: manage_ec2_instances}}
     - {include_role: {name: aws_workshop_login_page}, when: create_login_page is defined and create_login_page}
     - {include_role: {name: aws_dns}, when: create_login_page is defined and create_login_page}
+    - {include_role: {name: code_server}, when: code_server}
 
     - name: Remove workshop local files
       file:


### PR DESCRIPTION
##### SUMMARY
this will add SSL support to vs code and use a standard port (443) so that this will help folks that are new or have restrictions on using a terminal ssh based access to login

this also negates having to use vi, nano, emacs, etc if the student is not comfortable 

this was request from here: https://github.com/ansible/workshops/issues/569

there is a new DNS entry made for each student, for example student1.workshopname.myzone.io will also have student1-code.workshopname.myzone.io that will link to https:// and be working with a valid lets encrypt SSL cert

thanks @kyleabenson for the original PR and @cloin and @cigamit for pushing me to add SSL support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
this will look like this on the login page->
![example picture](https://i.imgur.com/FcEelVg.png)