### PR TITLE
Update AWS Marketplace links for Networking workshop

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -39,7 +39,7 @@ If you haven't done so already make sure you have the repo cloned to the machine
 
 6.  When doing a networking or F5 workshop make sure you have subscribed to the right marketplace AMI (Amazon Machine Image)
 
-  - For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/)
+  - For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/), the Arista vEOS Router [Click here](https://aws.amazon.com/marketplace/pp/B077YJYMK5/), AND the Juniper vSRX NextGen Firewall [Click here](https://aws.amazon.com/marketplace/pp/B01LYWCGDX/)
   - For F5 you will need the F5 BIG-IP [Click here](https://aws.amazon.com/marketplace/pp/B079C44MFH/)
 
 # Tower Instructions

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -379,7 +379,7 @@ $("document").ready(function(){
     <div class="content">
 {% for host in ansible_node_facts.instances %}
 {% if 'student' ~ number == host.tags.Student %}
-{% if code_server %}
+{% if code_server is defined and code_server %}
 <div id="section_title">VS Code access</div>
 To login to Visual Studio Code via your web browser please go here:<br>
 <table>
@@ -423,7 +423,7 @@ DNS: student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
 </div>
 <div id="tower_info">
 <hr>
-{% if towerinstall %}
+{% if towerinstall is defined and towerinstall %}
 <div id="section_title">Ansible Tower access</div>
 To login to the Ansible Tower UI use the following credentials:<br>
 <table>


### PR DESCRIPTION
##### SUMMARY
The newer Networking workshop uses not only Cisco but also Arista and Juniper virtual devices in AWS.

The documentation only had a link to the Cisco CSR subscription in the AWS Marketplace.  This fix adds the Arista and Juniper AWS Marketplace links to the documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- docs

##### ADDITIONAL INFORMATION
When deploying the Ansible for Networking workshop, the provisioner creates a number of virtual routing and switching devices in AWS.  These are enterprise-grade virtual networking devices from Arista, Cisco, and Juniper.

In order for the provisioner to deploy these devices, the workshop admin/proctor must first accept the licensing agreements and subscribe to the various virtual networking devices or else the provisioner will fail.

***Before***, docs/setup.md, line 42:
```
- For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/)
```

***After***, docs/setup.md, line 42:
```
- For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/), the Arista vEOS Router [Click here](https://aws.amazon.com/marketplace/pp/B077YJYMK5/), AND the Juniper vSRX NextGen Firewall [Click here](https://aws.amazon.com/marketplace/pp/B01LYWCGDX/)
```