### PR TITLE
Add other languages link on the top of Network Automation Workshop

### DIFF
--- a/exercises/ansible_network/README.md
+++ b/exercises/ansible_network/README.md
@@ -1,5 +1,7 @@
 # Ansible Network Automation Workshop
 
+**Read this in other languages**: ![uk](../../../images/uk.png) [English](README.md),  ![japan](../../../images/japan.png) [日本語](README.ja.md).
+
 This content is a multi-purpose toolkit for effectively demonstrating Ansible's capabilities on network equipment (Arista, Cisco, and Juniper) or providing informal workshop training in various forms -- instructor-led, hands-on or self-paced.
 
 ## Presentation


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Other workshop pages have correct language selection link but there is no link on top of the Network Automation Workshop. So I added other languages section to guide the Japanese edition of README.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- docs
