### PR TITLE
Add security workshop to provisioner/README.md

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -7,6 +7,7 @@ The `github.com/ansible/workshops` contains an Ansible Playbook `provision_lab.y
 | Ansible Red Hat Enterprise Linux Workshop | `workshop_type: rhel`  |
 | Ansible Network Automation Workshop | `workshop_type: networking`  |
 | Ansible F5 Workshop | `workshop_type: f5`   |
+| Ansible Security Automation | `workshop_type: security`   |
 
 # Table Of Contents
 - [Requirements](#requirements)


### PR DESCRIPTION
### SUMMARY

We forgot to add the security workshop to `provisioner/README.md`.
Speaking about, we list the available workshops at multiple places. We should consolidate those lists at some point.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- provisioner