### PR TITLE
Update provision_lab.yml

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -202,6 +202,8 @@
       when:
         - code_server is defined
         - code_server
+        - towerinstall is defined
+        - towerinstall
   tags: control_node
 
 - name: add dns entires for all student control nodes


### PR DESCRIPTION
##### SUMMARY
code-server only works if tower is installed the way this role works, this should fix issues that @liquidat has


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
the code-server role that sets up vscode requires that nginx is setup via Ansible Tower, this should fix issues where towerinstall is turned off (not on by default)
