### PR TITLE
Update to fix install of Ansible Vscode plugin.

### DIFF
--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -41,6 +41,8 @@
 
 - name: install ansible vscode extension
   command: "/home/{{username}}/{{ version_name }}/code-server --install-extension vscoss.vscode-ansible"
+  environment:
+    NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/ca-bundle.crt'
 
 - name: move binary to /opt
   copy:


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the correct location for certs to be used during the install of VScode extension.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes VSCode install of Ansible Extension
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
- name: install ansible vscode extension
  command: "/home/{{username}}/{{ version_name }}/code-server --install-extension vscoss.vscode-ansible"

After
- name: install ansible vscode extension
  command: "/home/{{username}}/{{ version_name }}/code-server --install-extension vscoss.vscode-ansible"
  environment:
    NODE_EXTRA_CA_CERTS: '/etc/ssl/certs/ca-bundle.crt'
```
