### PR TITLE
option to double student workbench (windows)

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/instances_windows.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_windows.yml
@@ -112,22 +112,22 @@
     user_data: "{{ lookup('template', 'skylight_windows_userdata.j2', template_vars=dict(vm_name='instance1')) }}"
   register: instance1_output
 
-
-# - name: WINDOWS | Create workstation
-#   ec2:
-#     assign_public_ip: true
-#     key_name: "{{ ec2_name_prefix }}-key"
-#     group: "{{ ec2_name_prefix }}-windows"
-#     instance_type: "{{ ec2_info['skylight_windows_ws']['size'] }}"
-#     image: "{{ win_ws_ami.image_id }}"
-#     region: "{{ ec2_region }}"
-#     exact_count: "{{ student_total }}"
-#     count_tag:
-#       Workshop_workstation: "{{ ec2_name_prefix }}-workstation"
-#     wait: "{{ ec2_wait }}"
-#     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
-#     user_data: "{{ lookup('template', 'skylight_windows_userdata.j2', template_vars=dict(vm_name='workstation')) }}"
-#   register: workstation_output
+- name: WINDOWS | Create instance 2
+  ec2:
+    assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    group: "{{ ec2_name_prefix }}-windows"
+    instance_type: "{{ ec2_info['skylight_windows_instance']['size'] }}"
+    image: "{{ win_instance_ami.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total }}"
+    count_tag:
+      Workshop_instance1: "{{ ec2_name_prefix }}-instance1"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    user_data: "{{ lookup('template', 'skylight_windows_userdata.j2', template_vars=dict(vm_name='instance1')) }}"
+  register: instance2_output
+  when: doubleup|bool
 
 ### tag student workbench
 
@@ -154,25 +154,27 @@
     - "{{ instance1_output.instances }}"
   when: instance1_output.instance_ids is not none
 
-# - name: WINDOWS | Ensure tags are present for workstation
-#   ec2_tag:
-#     region: "{{ ec2_region }}"
-#     resource: "{{item.1.id}}"
-#     state: present
-#     tags:
-#       Workshop_workstation: "{{ ec2_name_prefix }}-workstation"
-#       Name: "{{ ec2_name_prefix }}-student{{item.0 + 1}}-workstation"
-#       App: AnsibleWorkshop
-#       Workshop: "{{ec2_name_prefix}}"
-#       Workshop_type: "{{ workshop_type }}"
-#       Index: "{{ item[0] }}"
-#       Student: "student{{item.0 + 1}}"
-#       AWS_USERNAME: "{{ aws_user }}"
-#       Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
-#       Linklight: "This was provisioned through the linklight provisioner"
-#       Students: "{{student_total}}"
-#       short_name: "workstation"
-#       launch_time: "{{item.1.launch_time}}"
-#   with_indexed_items:
-#     - "{{ workstation_output.instances }}"
-#   when: workstation_output.instance_ids is not none
+- name: WINDOWS | Ensure tags are present for instance 2
+  ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{item.1.id}}"
+    state: present
+    tags:
+      Workshop_instance1: "{{ ec2_name_prefix }}-instance2"
+      Name: "{{ ec2_name_prefix }}-student{{item.0 + 1}}-instance2"
+      App: AnsibleWorkshop
+      Workshop: "{{ec2_name_prefix}}"
+      Workshop_type: "{{ workshop_type }}"
+      Index: "{{ item[0] }}"
+      Student: "student{{item.0 + 1}}"
+      AWS_USERNAME: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{student_total}}"
+      short_name: "instance2"
+      launch_time: "{{item.1.launch_time}}"
+  with_indexed_items:
+    - "{{ instance2_output.instances }}"
+  when: 
+    - doubleup|bool
+    - instance2_output.instance_ids is not none

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_windows.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_windows.yml
@@ -175,6 +175,6 @@
       launch_time: "{{item.1.launch_time}}"
   with_indexed_items:
     - "{{ instance2_output.instances }}"
-  when: 
+  when:
     - doubleup|bool
     - instance2_output.instance_ids is not none

--- a/provisioner/sample_workshops/sample-vars-windows.yml
+++ b/provisioner/sample_workshops/sample-vars-windows.yml
@@ -8,6 +8,8 @@ ec2_name_prefix: TESTWORKSHOP
 
 # creates student_total of workbenches for the workshop
 student_total: 2
+# creates 2 windows instances per student instead of default 1
+doubleup: false
 # Set the right workshop type, like networking, rhel or f5 (see above)
 workshop_type: windows
 # OPTIONAL VARIABLES


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds option to have 2 windows instances per student to facilitate additional demo usecases
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
