### PR TITLE
Add verify playbook for rhel workshop

### DIFF
--- a/provisioner/tests/README.md
+++ b/provisioner/tests/README.md
@@ -26,3 +26,21 @@ To run the walkthrough tests, the playbook `security_exercise_21.yml` needs to b
 ```
 ansible-playbook provisioner/tests/security_exercise_21.yml -i provisioner/test-workshop/student4-instances.txt
 ```
+
+## RHEL testing
+
+There is currently a deployment test available. Current tests:
+
+- Availabilitiy of all machines
+- Right Ansible version installed on control host
+- Necessary Python libs are installed on control host to run Tower modules
+- Tower itself is installed
+- Tower license is configured and valid (login test)
+- Tower is working and provides API feedback
+
+The tower password as well as the workshop name must be provided on the command line.
+
+```
+ansible-playbook provisioner/tests/rhel_verify.yml -i provisioner/test-workshop/instructor_inventory.txt --private-key=provisioner/test-workshop/test-workshop-private.pem -e tower_password=mypwd -e workshop_name=test-workshop
+```
+

--- a/provisioner/tests/gating.groovy
+++ b/provisioner/tests/gating.groovy
@@ -107,6 +107,22 @@ EOF
                             }
                         }
                         script {
+                            stage('RHEL-verify') {
+                                withCredentials([string(credentialsId: 'workshops_aws_access_key', variable: 'AWS_ACCESS_KEY'),
+                                                 string(credentialsId: 'workshops_aws_secret_key', variable: 'AWS_SECRET_KEY')]) {
+                                    withEnv(["AWS_SECRET_KEY=${AWS_SECRET_KEY}",
+                                             "AWS_ACCESS_KEY=${AWS_ACCESS_KEY}",
+                                             "ANSIBLE_CONFIG=provisioner/ansible.cfg",
+                                             "ANSIBLE_FORCE_COLOR=true"]) {
+                                        sh """ansible-playbook provisioner/tests/rhel_verify.yml \
+                                                -i provisioner/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BRANCH_NAME}-${env.BUILD_ID}/instructor_inventory.txt \
+                                                --private-key=provisioner/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BRANCH_NAME}-${env.BUILD_ID}/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BRANCH_NAME}-${env.BUILD_ID}-private.pem \
+                                                -e tower_password=${ADMIN_PASSWORD} -e workshop_name=tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BRANCH_NAME}-${env.BUILD_ID}"""
+                                    }
+                                }
+                            }
+                        }
+                        script {
                             stage('RHEL-teardown') {
                                 withCredentials([string(credentialsId: 'workshops_aws_access_key', variable: 'AWS_ACCESS_KEY'),
                                                  string(credentialsId: 'workshops_aws_secret_key', variable: 'AWS_SECRET_KEY')]) {

--- a/provisioner/tests/pipeline.groovy
+++ b/provisioner/tests/pipeline.groovy
@@ -141,6 +141,22 @@ EOF
                             }
                         }
                         script {
+                            stage('RHEL-verify') {
+                                withCredentials([string(credentialsId: 'workshops_aws_access_key', variable: 'AWS_ACCESS_KEY'),
+                                                 string(credentialsId: 'workshops_aws_secret_key', variable: 'AWS_SECRET_KEY')]) {
+                                    withEnv(["AWS_SECRET_KEY=${AWS_SECRET_KEY}",
+                                             "AWS_ACCESS_KEY=${AWS_ACCESS_KEY}",
+                                             "ANSIBLE_CONFIG=provisioner/ansible.cfg",
+                                             "ANSIBLE_FORCE_COLOR=true"]) {
+                                        sh """ansible-playbook provisioner/tests/rhel_verify.yml \
+                                                -i provisioner/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BUILD_ID}-${SHORTENED_ANSIBLE_VERSION}/instructor_inventory.txt \
+                                                --private-key=provisioner/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BUILD_ID}-${SHORTENED_ANSIBLE_VERSION}/tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BUILD_ID}-${SHORTENED_ANSIBLE_VERSION}-private.pem \
+                                                -e tower_password=${ADMIN_PASSWORD} -e workshop_name=tqe-rhel-tower${DOTLESS_TOWER_VERSION}-${env.BUILD_ID}-${SHORTENED_ANSIBLE_VERSION}"""
+                                    }
+                                }
+                            }
+                        }
+                        script {
                             stage('RHEL-teardown') {
                                 withCredentials([string(credentialsId: 'workshops_aws_access_key', variable: 'AWS_ACCESS_KEY'),
                                                  string(credentialsId: 'workshops_aws_secret_key', variable: 'AWS_SECRET_KEY')]) {

--- a/provisioner/tests/rhel_verify.yml
+++ b/provisioner/tests/rhel_verify.yml
@@ -1,0 +1,25 @@
+---
+- name: Check each student environment
+  hosts: all
+  gather_facts: true
+
+  tasks:
+    - name: Control host
+      block:
+        - name: Check if ansible is installed
+          package_facts:
+
+        - name: Fail if ansible is not of a recent enough version
+          fail:
+            msg: "Ansible is not of a recent enough version on {{ inventory_hostname }}."
+          when: ((ansible_facts.packages['ansible'][0]['version'] is not defined) or (ansible_facts.packages['ansible'][0]['version']|string) is version("2.9.0",'<'))
+
+        - name: Test access by exporting assets
+          tower_receive:
+            inventory:
+              - all
+            tower_host: "{{ inventory_hostname|regex_replace('-ansible', '') }}.{{ workshop_name }}.rhdemo.io"
+            tower_username: admin
+            tower_password: "{{ tower_password }}"
+
+      when: '"ansible" in inventory_hostname'


### PR DESCRIPTION

##### SUMMARY

Add simple verify playbook to verify deployment.

- Availabilitiy of all machines
- Right Ansible version installed on control host
- Necessary Python libs are installed on control host to run Tower modules
- Tower itself is installed
- Tower license is configured and valid (login test)
- Tower is working and provides API feedback

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- provisioner
