### PR TITLE
AMI find

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
@@ -1,0 +1,15 @@
+---
+
+- name: find ami for node1
+  ec2_ami_facts:
+    region: "{{ ec2_region }}"
+    owners: "{{ ec2_info[rhel].owners }}"
+    filters:
+      name: "{{ ec2_info[rhel].filter }}"
+      architecture: "{{ ec2_info[rhel].architecture }}"
+  register: amis
+
+- name: save ami for node1
+  set_fact:
+    node_ami: >
+      {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: find ami for node1
+- name: find ami for node
   ec2_ami_facts:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
@@ -9,7 +9,7 @@
       architecture: "{{ ec2_info[rhel].architecture }}"
   register: amis
 
-- name: save ami for node1
+- name: save ami for node
   set_fact:
     node_ami: >
       {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_rhel.yml
@@ -1,17 +1,6 @@
 ---
-- name: find ami for node1
-  ec2_ami_facts:
-    region: "{{ ec2_region }}"
-    owners: "{{ ec2_info[rhel].owners }}"
-    filters:
-      name: "{{ ec2_info[rhel].filter }}"
-      architecture: "{{ ec2_info[rhel].architecture }}"
-  register: amis
-
-- name: save ami for node1
-  set_fact:
-    node1_ami: >
-      {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
+- name: find amis
+  import_tasks: ami_find_rhel.yml
 
 - name: Create EC2 instances for node1
   ec2:
@@ -19,7 +8,7 @@
     key_name: "{{ ec2_name_prefix }}-key"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[rhel].size }}"
-    image: "{{ node1_ami.image_id }}"
+    image: "{{ node_ami.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     count_tag:
@@ -55,27 +44,13 @@
     - "{{ node1_output.instances }}"
   when: node1_output.instance_ids is not none
 
-- name: find ami for node2
-  ec2_ami_facts:
-    region: "{{ ec2_region }}"
-    owners: "{{ ec2_info[rhel].owners }}"
-    filters:
-      name: "{{ ec2_info[rhel].filter }}"
-      architecture: "{{ ec2_info[rhel].architecture }}"
-  register: amis
-
-- name: save ami for node2
-  set_fact:
-    node2_ami: >
-      {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
-
 - name: Create EC2 instances for node2
   ec2:
     assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[rhel].size }}"
-    image: "{{ node2_ami.image_id }}"
+    image: "{{ node_ami.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     count_tag:
@@ -111,27 +86,13 @@
     - "{{ node2_output.instances }}"
   when: node2_output.instance_ids is not none
 
-- name: find ami for node3
-  ec2_ami_facts:
-    region: "{{ ec2_region }}"
-    owners: "{{ ec2_info[rhel].owners }}"
-    filters:
-      name: "{{ ec2_info[rhel].filter }}"
-      architecture: "{{ ec2_info[rhel].architecture }}"
-  register: amis
-
-- name: save ami for node3
-  set_fact:
-    node3_ami: >
-      {{ amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
-
 - name: Create EC2 instances for node3
   ec2:
     assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[rhel].size }}"
-    image: "{{ node3_ami.image_id }}"
+    image: "{{ node_ami.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     count_tag:


### PR DESCRIPTION
##### SUMMARY
There is a separate ami_find_*.yml for some of the workshop_type's in the manage_ec2_instnaces role, but not for the rhel workshop.

This PR is adding the necessary ami_find_rhel.yml and the changes in instances_rhel.yml

This will improve the provisioning time slightly and better align all workshop_type's.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
