### PR TITLE
Move static files and templates into subdirectory

### DIFF
--- a/exercises/ansible_rhel/1.3-playbook/README.md
+++ b/exercises/ansible_rhel/1.3-playbook/README.md
@@ -214,7 +214,13 @@ Check that the tasks were executed correctly and Apache is accepting connections
 
 There are a lot of red lines and an error: As long as there is not at least an `index.html` file to be served by Apache, it will throw an ugly "HTTP Error 403: Forbidden" status and Ansible will report an error.
 
-So why not use Ansible to deploy a simple `index.html` file? Create the file `~/ansible-files/index.html` on the control node:
+So why not use Ansible to deploy a simple `index.html` file? On the ansible control host, as the `student<X>` user, create the directory `files` to hold file resources in `~/ansible-files/`:
+
+```bash
+[student<X>@ansible ansible-files]$ mkdir files
+```
+
+Then create the file `~/ansible-files/files/index.html` on the control node:
 
 ```html
 <body>
@@ -243,7 +249,7 @@ On the control node as your student user edit the file `~/ansible-files/apache.y
       state: started
   - name: copy index.html
     copy:
-      src: ~/ansible-files/index.html
+      src: index.html
       dest: /var/www/html/
 ```
 
@@ -298,7 +304,7 @@ Change the Playbook to point to the group "web":
       state: started
   - name: copy index.html
     copy:
-      src: ~/ansible-files/index.html
+      src: index.html
       dest: /var/www/html/
 ```
 

--- a/exercises/ansible_rhel/1.4-variables/README.md
+++ b/exercises/ansible_rhel/1.4-variables/README.md
@@ -64,7 +64,7 @@ What is this about?
 
 ## Step 4.2 - Create index.html Files
 
-Now create two files in `~/ansible-files/`:
+Now create two files in `~/ansible-files/files/`:
 
 One called `prod_index.html` with the following content:
 
@@ -101,7 +101,7 @@ Create a new Playbook called `deploy_index_html.yml` in the `~/ansible-files/` d
   tasks:
   - name: copy index.html
     copy:
-      src: ~/ansible-files/{{ stage }}_index.html
+      src: {{ stage }}_index.html
       dest: /var/www/html/index.html
 ```
 <!-- {% endraw %} -->

--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -85,7 +85,7 @@ As a an example, let’s write a Playbook that:
 First we need the file Ansible will deploy, let’s just take the one from node1. Remember to replace the IP address shown in the listing below with the IP address from your individual `node1`.
 
 ```bash
-[student<X>@ansible ansible-files]$ scp 11.22.33.44:/etc/httpd/conf/httpd.conf ~/ansible-files/.
+[student<X>@ansible ansible-files]$ scp 11.22.33.44:/etc/httpd/conf/httpd.conf ~/ansible-files/files/.
 student<X>@11.22.33.44's password:
 httpd.conf             
 ```

--- a/exercises/ansible_rhel/1.6-templates/README.md
+++ b/exercises/ansible_rhel/1.6-templates/README.md
@@ -10,7 +10,13 @@ When a template for a file has been created, it can be deployed to the managed h
 
 As an example of using templates you will change the motd file to contain host-specific data.
 
-First in the `~/ansible-files/` directory create the template file `motd-facts.j2`:
+First create the directory `templates` to hold template resources in `~/ansible-files/`:
+
+```bash
+[student<X>@ansible ansible-files]$ mkdir templates
+```
+
+Then in the `~/ansible-files/templates/` directory create the template file `motd-facts.j2`:
 
 <!-- {% raw %} -->
 ```html+jinja


### PR DESCRIPTION
##### SUMMARY
Move static and template files into their subdirectories. The first exercises are a good starting point to teach best practices.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
Only the english RHEL exercise README.md files are updated. Has still to be done for the other translations.