### PR TITLE
Make provisioner more compatible with running from tower

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -59,6 +59,11 @@
   hosts: control_nodes
   gather_facts: true
   become: true
+  vars:
+    tower_license: "{{ hostvars['localhost']['tower_license'] }}"
+  pre_tasks:
+    - debug:
+        var: tower_license
   roles:
     - role: control_node
   tasks:
@@ -155,7 +160,6 @@
 - name: print out information for instructor
   hosts: localhost
   connection: local
-  become:
   gather_facts: false
   tasks:
     - name: set facts for output

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -68,27 +68,45 @@
     group: "{{ username }}"
     state: directory
 
-- name: copy over ssh config file
+# This may look redundant, but you can't put these in a loop because the
+# ansible_user will not be templated the way you expect when running under
+# Tower/AWX
+
+- name: copy over ssh config file for student
   template:
     src: sshconfig.j2
-    dest: /home/{{item}}/.ssh/config
-    owner: "{{item}}"
-    group: "{{item}}"
+    dest: /home/{{ username }}/.ssh/config
+    owner: "{{ username }}"
+    group: "{{ username }}"
     mode: 0700
-  loop:
-    - "{{ansible_user}}"
-    - "{{username}}"
 
 - name: Put ssh-key in proper spot for student
   copy:
     src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
-    dest: "/home/{{item}}/.ssh/aws-private.pem"
-    owner: "{{ item }}"
-    group: "{{ item }}"
+    dest: "/home/{{ ansible_user }}/.ssh/aws-private.pem"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: 0400
-  loop:
-    - "{{ansible_user}}"
-    - "{{username}}"
+
+# It isn't really safe to use ansible_user, because it could be resolved
+# in different ways, depending on where it's used.
+# It should work as expected below. -ptoal
+
+- name: copy over ssh config file for ansible_user
+  template:
+    src: sshconfig.j2
+    dest: /home/{{ ansible_user }}/.ssh/config
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: 0700
+
+- name: Put ssh-key in proper spot for student
+  copy:
+    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    dest: "/home/{{ username }}/.ssh/aws-private.pem"
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: 0400
 
 - name: clean out /tmp/workshops
   file:

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -97,19 +97,13 @@
     tower_host: "{{ ansible_host }}"
     tower_verify_ssl: false
 
-- name: Ensure eula is accepted if posting license
-  command: python -c "import json; license = json.loads(open('{{playbook_dir}}/tower_license.json', 'r').read()); ceula = license.get('eula_accepted'); license['eula_accepted'] = True if not ceula else ceula ; open('{{playbook_dir}}/tower_license.json', 'w').write(json.dumps(license));"
-  delegate_to: localhost
-  run_once: true
-  become: false
-
 - name: Post license key
   uri:
     url: https://{{ansible_host}}/api/v2/config/
     method: POST
     user: admin
     password: "{{admin_password}}"
-    body: "{{ lookup('file',playbook_dir+'/tower_license.json') }}"
+    body: "{{ tower_license }}"
     body_format: json
     validate_certs: false
     force_basic_auth: true

--- a/provisioner/roles/manage_ec2_instances/tasks/resources/resources.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/resources/resources.yml
@@ -196,7 +196,7 @@
 - name: save private key
   copy:
     content: "{{ create_key.key.private_key }}"
-    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    dest: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     mode: '0400'
   when: create_key.changed
 
@@ -205,7 +205,7 @@
     bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
     mode: put
     object: "{{ec2_name_prefix}}-private.pem"
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    src: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     encrypt: true
     region: "{{ ec2_region }}"
   when: create_key.changed
@@ -214,15 +214,15 @@
   aws_s3:
     bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
     mode: get
-    object: "{{ec2_name_prefix}}-private.pem"
-    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    object: "{{ ec2_name_prefix }}-private.pem"
+    dest: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     encrypt: true
     region: "{{ ec2_region }}"
   when: not create_key.changed
 
 - name: Ensure key file has proper permissions
   file:
-    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    dest: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
     mode: 0600
 
 - name: debugging all variables for ec2 instance creation VPC-1

--- a/provisioner/roles/manage_ec2_instances/tasks/resources/resources.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/resources/resources.yml
@@ -176,6 +176,17 @@
     ec2_vpc_subnet_id: "{{ create_subnet.subnet.id }}"
     ec2_vpc_subnet2_id: "{{ create_subnet2.subnet.id }}"
 
+- name: s3 bucket for persistent storage of ec2 key exists
+  s3_bucket:
+    name: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}.private"
+    state: present
+    region: "{{ ec2_region }}"
+  retries: 4
+  delay: 15
+  register: s3_result
+  until:
+    - s3_result.failed == false
+
 - name: Create ssh key pair for workshop {{ ec2_name_prefix }}
   ec2_key:
     name: "{{ ec2_name_prefix }}-key"
@@ -185,9 +196,34 @@
 - name: save private key
   copy:
     content: "{{ create_key.key.private_key }}"
-    dest: "{{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem"
+    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
     mode: '0400'
   when: create_key.changed
+
+- name: Store SSH Key Pair
+  aws_s3:
+    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
+    mode: put
+    object: "{{ec2_name_prefix}}-private.pem"
+    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    encrypt: true
+    region: "{{ ec2_region }}"
+  when: create_key.changed
+
+- name: Save Private key from S3 Bucket when not generating it
+  aws_s3:
+    bucket: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}.private"
+    mode: get
+    object: "{{ec2_name_prefix}}-private.pem"
+    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    encrypt: true
+    region: "{{ ec2_region }}"
+  when: not create_key.changed
+
+- name: Ensure key file has proper permissions
+  file:
+    dest: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    mode: 0600
 
 - name: debugging all variables for ec2 instance creation VPC-1
   debug:

--- a/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
@@ -337,7 +337,7 @@
     name: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}.private"
     state: absent
     region: "{{ ec2_region }}"
-    force: yes
+    force: true
   retries: 4
   delay: 15
   register: s3_result

--- a/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
@@ -332,6 +332,18 @@
     region: "{{ ec2_region }}"
     state: absent
 
+- name: delete s3 bucket for persistent storage of ec2 key
+  s3_bucket:
+    name: "{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}.private"
+    state: absent
+    region: "{{ ec2_region }}"
+    force: yes
+  retries: 4
+  delay: 15
+  register: s3_result
+  until:
+    - s3_result.failed == false
+
 # delete VPCS
 - name: delete AWS VPC {{ ec2_name_prefix }}
   ec2_vpc_net:

--- a/provisioner/roles/workshop_check_setup/tasks/main.yml
+++ b/provisioner/roles/workshop_check_setup/tasks/main.yml
@@ -81,12 +81,24 @@
     - debug:
         var: stat_result
     - fail:
-        msg: "autolicense is turned on, but we need a license located at {{playbook_dir}}/tower_license.json"
+        msg: "Need tower_license_data in extra_vars or a license located at {{playbook_dir}}/tower_license.json"
       when:
         - not stat_result.stat.exists
+    - set_fact:
+        tower_license: "{{ lookup('file',playbook_dir+'/tower_license.json')|from_json|combine({'eula_accepted':true}) }}"
   when:
-    - towerinstall is defined
-    - towerinstall
+    - tower_license_data is not defined
+
+- set_fact:
+    tower_license: "{{ tower_license_data|from_json|combine({'eula_accepted':true}) }}"
+  when:
+    - tower_license is not defined
+
+- name: Ensure tower license is not expired
+  assert:
+    that: ansible_date_time.epoch|int < tower_license.license_date|int
+    fail_msg: "WARNING: Ansible Tower License expired."
+  ignore_errors: true
 
 - name: install product_demos collection
   shell: "{{item}}"


### PR DESCRIPTION
##### SUMMARY
This change makes it possible to run the provisioner from Ansible Tower > 3.6 (See #709 )

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
There are two major changes here:
1. Tower License data is now taken from extra_vars, as well as from disk.  This allows providing the tower license data from tower, without depending on local disk access, which is now ephemeral in Tower.

2. Temporary EC2 private keys are now stored in an S3 bucket, so they can be used in successive playbook runs.  Since they are only ever accessible during creation, they need to be saved if the playbook needs to be run multiple times.  Again, it is no longer possible to persist them on the Tower server.

In future, other ephemeral files should be stored somewhere like the S3 bucket, so that they do not depend on persisting any state in Tower.

