### PR TITLE
replace some deprecated modules

### DIFF
--- a/provisioner/roles/aws_check_setup/tasks/main.yml
+++ b/provisioner/roles/aws_check_setup/tasks/main.yml
@@ -36,7 +36,7 @@
     - create_login_page|bool
 
 - name: FIND AZ ZONE FOR REGION {{ec2_region}}
-  aws_az_facts:
+  aws_az_info:
     region: "{{ec2_region}}"
   register: az_names
 
@@ -44,7 +44,7 @@
   set_fact: ec2_az={{az_names.availability_zones[0].zone_name}}
 
 - name: grab information about AWS user
-  aws_caller_facts:
+  aws_caller_info:
     region: "{{ ec2_region }}"
   register: whoami
 

--- a/provisioner/roles/aws_dns/tasks/teardown.yml
+++ b/provisioner/roles/aws_dns/tasks/teardown.yml
@@ -5,7 +5,7 @@
   register: AWSINFO
 
 - name: GRAB ROUTE53 INFORMATION
-  route53_facts:
+  route53_info:
     type: A
     query: record_sets
     hosted_zone_id: "{{AWSINFO.zone_id}}"

--- a/provisioner/roles/code_server/tasks/teardown.yml
+++ b/provisioner/roles/code_server/tasks/teardown.yml
@@ -5,7 +5,7 @@
   register: AWSINFO
 
 - name: GRAB ROUTE53 INFORMATION
-  route53_facts:
+  route53_info:
     type: A
     query: record_sets
     hosted_zone_id: "{{AWSINFO.zone_id}}"

--- a/provisioner/roles/cp_setup/tasks/main.yml
+++ b/provisioner/roles/cp_setup/tasks/main.yml
@@ -64,7 +64,7 @@
       {}
 
 - name: get gw instances
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       "tag:Name": "{{ inventory_hostname|regex_replace('ansible', 'checkpoint_gw') }}"

--- a/provisioner/roles/gather_router_facts/tasks/main.yml
+++ b/provisioner/roles/gather_router_facts/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for rtr1
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -9,7 +9,7 @@
   delegate_to: localhost
 
 - name: grab facts for rtr2
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -18,7 +18,7 @@
   delegate_to: localhost
 
 - name: grab facts for rtr3
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -27,7 +27,7 @@
   delegate_to: localhost
 
 - name: grab facts for rtr4
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_devops.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_devops.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for node1 - dev_web1
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -9,7 +9,7 @@
   register: node1_node_facts
 
 - name: grab facts for node2 node - dev_web2
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -18,7 +18,7 @@
   register: node2_node_facts
 
 - name: grab facts for node3 node - prod_web1
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -27,7 +27,7 @@
   register: node3_node_facts
 
 - name: grab facts for node4 node - prod_web2
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_f5.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_f5.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for f5 node (F5 MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -22,7 +22,7 @@
   with_items: "{{ f5_node_facts.instances }}"
 
 - name: grab facts for host1 node (F5 MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -45,7 +45,7 @@
   with_items: "{{ host1_node_facts.instances }}"
 
 - name: grab facts for host2 node (F5 MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_networking.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for rtr1 node (NETWORKING MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -8,7 +8,7 @@
   register: rtr1_node_facts
 
 - name: grab facts for rtr2 node (NETWORKING MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -16,7 +16,7 @@
   register: rtr2_node_facts
 
 - name: grab facts for rtr3 node (NETWORKING MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -24,7 +24,7 @@
   register: rtr3_node_facts
 
 - name: grab facts for rtr4 node (NETWORKING MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_rhel.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for node1 node
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -8,7 +8,7 @@
   register: node1_node_facts
 
 - name: grab facts for node2 node
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -16,7 +16,7 @@
   register: node2_node_facts
 
 - name: grab facts for node3 node
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_security.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_security.yml
@@ -3,7 +3,7 @@
   when: security_console == 'splunk'
   block:
     - name: grab facts for splunknode (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -32,7 +32,7 @@
   when: security_console == 'qradar'
   block:
     - name: grab facts for qradarnode (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -60,7 +60,7 @@
 - name: MANAGE ATTACK SIMULATION EC2 INSTANCES (SECURITY MODE)
   block:
     - name: grab facts for attack simulation node (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -86,7 +86,7 @@
       loop: "{{ attacker_node_facts.instances|flatten(levels=1) }}"
 
 - name: grab facts for Check Point CloudGuard Security Management (SECURITY MODE)
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -96,7 +96,7 @@
 - name: MANAGE SNORT EC2 INSTANCES (SECURITY MODE)
   block:
     - name: grab facts for snort node (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -125,7 +125,7 @@
 - name: MANAGE CHECK POINT EC2 INSTANCES (SECURITY MODE)
   block:
     - name: grab facts for Check Point CloudGuard Security Management (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -150,7 +150,7 @@
       loop: "{{ checkpoint_node_facts.instances|flatten(levels=1) }}"
 
     - name: grab facts for Check Point NGFW (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running
@@ -177,7 +177,7 @@
 - name: MANAGE WINDOWS EC2 INSTANCES (SECURITY MODE)
   block:
     - name: grab facts for Windows workstation for Check Point (SECURITY MODE)
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/addhost_windows.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/addhost_windows.yml
@@ -2,7 +2,7 @@
 ################### Get workshop nodes info ###################
 
 - name: grab facts for Gitlab
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -10,7 +10,7 @@
   register: gitlab_node_facts
 
 - name: grab facts for instance 1
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -18,7 +18,7 @@
   register: instance1_node_facts
 
 - name: grab facts for instance 2
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_networking.yml
@@ -3,7 +3,7 @@
 - name: BLOCK FOR CISCO AMI
   block:
     - name: find ami for cisco (NETWORKING MODE)
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:
@@ -21,7 +21,7 @@
 - name: BLOCK FOR ARISTA AMI
   block:
     - name: find ami for arista (NETWORKING MODE)
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:
@@ -39,7 +39,7 @@
 - name: BLOCK FOR ARISTA AMI
   block:
     - name: find ami for juniper vsrx (NETWORKING MODE)
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_rhel.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: find ami for node
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
     filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_security.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_security.yml
@@ -4,7 +4,7 @@
   when: security_console == 'splunk'
   block:
     - name: find ami for splunk
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"  # I don't know why but that seems to be the only place it's available
         owners: "{{ ec2_info['splunk_enterprise']['owners'] }}"
         filters:
@@ -22,7 +22,7 @@
   when: security_console == 'qradar'
   block:
     - name: find ami for qradar
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"  # I don't know why but that seems to be the only place it's available
         owners: "{{ ec2_info['qradar']['owners'] }}"
         filters:
@@ -39,7 +39,7 @@
 - name: BLOCK FOR SNORT AMI
   block:
     - name: find ami for snort
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "{{ ec2_info['rhel7']['owners'] }}"
         filters:
@@ -56,7 +56,7 @@
 - name: BLOCK FOR ATTACKER AMI
   block:
     - name: find ami for attack simulation node
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "{{ ec2_info['rhel7']['owners'] }}"
         filters:
@@ -73,7 +73,7 @@
 - name: BLOCK FOR CHECK POINT AMI
   block:
     - name: find ami for check point management server (SECURITY MODE)
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         owners: "{{ ec2_info['checkpoint_mgmt']['owners'] }}"
         filters:
@@ -105,7 +105,7 @@
 - name: BLOCK FOR WINDOWS WORKSTATION AMI
   block:
     - name: find ami for windows workstation
-      ec2_ami_facts:
+      ec2_ami_info:
         region: "{{ ec2_region }}"
         filters:
           name: "{{ ec2_info['windows_ws']['filter'] }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/ami_find_windows.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/ami_find_windows.yml
@@ -1,6 +1,6 @@
 ---
 # - name: WINDOWS | DomainController | find ami
-#   ec2_ami_facts:
+#   ec2_ami_info:
 #     region: "{{ ec2_region }}"
 #     filters:
 #       name: "{{ ec2_info['skylight_windows_dc']['filter'] }}"
@@ -13,7 +13,7 @@
 
 
 - name: WINDOWS | GitLab | find ami
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     filters:
       name: "{{ ec2_info['skylight_rhel7_gitlab']['filter'] }}"
@@ -26,7 +26,7 @@
 
 
 # - name: WINDOWS | Docs | find ami
-#   ec2_ami_facts:
+#   ec2_ami_info:
 #     region: "{{ ec2_region }}"
 #     filters:
 #       name: "{{ ec2_info['skylight_rhel7_docs']['filter'] }}"
@@ -39,7 +39,7 @@
 
 
 - name: WINDOWS | Instance | find ami
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     filters:
       name: "{{ ec2_info['skylight_windows_instance']['filter'] }}"
@@ -52,7 +52,7 @@
 
 
 # - name: WINDOWS | Workstation | find ami
-#   ec2_ami_facts:
+#   ec2_ami_info:
 #     region: "{{ ec2_region }}"
 #     filters:
 #       name: "{{ ec2_info['skylight_windows_ws']['filter'] }}"

--- a/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/create_inventory.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for control_nodes
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_devops.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_devops.yml
@@ -1,6 +1,6 @@
 ---
 - name: find ami for node1
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
     filters:
@@ -57,7 +57,7 @@
   when: node1_output.instance_ids is not none
 
 - name: find ami for node2
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
     filters:
@@ -114,7 +114,7 @@
   when: node2_output.instance_ids is not none
 
 - name: find ami for node3
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
     filters:
@@ -171,7 +171,7 @@
   when: node3_output.instance_ids is not none
 
 - name: find ami for node4
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[rhel].owners }}"
     filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_f5.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_f5.yml
@@ -1,7 +1,7 @@
 ---
 ############## f5 node ##############
 - name: find ami for f5 (F5 MODE)
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info.f5node.owners }}"
     filters:
@@ -51,7 +51,7 @@
   when: f5_output.instance_ids is not none
 
 - name: find ami for host1 & host2 (F5 MODE)
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info.rhel7.owners }}"
     filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/instances_storage.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances_storage.yml
@@ -1,6 +1,6 @@
 ---
 - name: find ami for netapp
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[netapp].owners }}"
     filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/provision.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/provision.yml
@@ -15,7 +15,7 @@
   when: workshop_type == 'networking'
 
 - name: find ami for ansible control node
-  ec2_ami_facts:
+  ec2_ami_info:
     region: "{{ ec2_region }}"
     owners: "{{ ec2_info[control_type].owners }}"
     filters:

--- a/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/teardown.yml
@@ -71,7 +71,7 @@
       when: debug_teardown
 
     - name: grab vpc node facts for workshop
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           "vpc-id": "{{ec2_vpc_id}}"
@@ -83,7 +83,7 @@
       when: debug_teardown
 
     - name: grab vpc2 node facts for workshop
-      ec2_instance_facts:
+      ec2_instance_info:
         region: "{{ ec2_region }}"
         filters:
           "vpc-id": "{{ec2_vpc_id2}}"
@@ -264,14 +264,14 @@
         - vpc_net_facts2.vpcs|length > 0
 
     - name: grab route information for {{ ec2_name_prefix }} on {{ ec2_region }}
-      ec2_vpc_route_table_facts:
+      ec2_vpc_route_table_info:
         region: "{{ ec2_region }}"
         filters:
           vpc_id: "{{ec2_vpc_id}}"
       register: route_table_facts
 
     - name: grab route information for {{ ec2_name_prefix }} on {{ ec2_region }} vpc2 (NETWORKING MODE)
-      ec2_vpc_route_table_facts:
+      ec2_vpc_route_table_info:
         region: "{{ ec2_region }}"
         filters:
           vpc_id: "{{ec2_vpc_id2}}"

--- a/provisioner/roles/network_hostroutes/tasks/main.yml
+++ b/provisioner/roles/network_hostroutes/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: grab facts for rtr1
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running
@@ -9,7 +9,7 @@
   delegate_to: localhost
 
 - name: grab facts for rtr2
-  ec2_instance_facts:
+  ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
       instance-state-name: running

--- a/provisioner/roles/splunk_enterprise/tasks/main.yml
+++ b/provisioner/roles/splunk_enterprise/tasks/main.yml
@@ -7,7 +7,7 @@
       register: AWSINFO
 
     - name: GRAB ROUTE53 INFORMATION
-      route53_facts:
+      route53_info:
         type: A
         query: record_sets
         hosted_zone_id: "{{AWSINFO.zone_id}}"


### PR DESCRIPTION
### SUMMARY
This PR solves somes ansible-playbook deprecation warnings by replacing them with the new and updated module.

e.g. aws_az_facts -> aws_az_info

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
Since these modules do not introduce any additional changes, it should be save to just replace them with the new version. 