### PR TITLE
testing new s3 workshop page

### DIFF
--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -216,19 +216,28 @@ a {
 $("document").ready(function(){
   $click =  $('.studentinfo');   // Click selector
 
-
   $click.click(function () {
 
     $clicked = $(this);
+    
     $expand = $(this).parent('.header').next();  // Expand and collapse content selector
 
         //open up the content needed - toggle the slide- if visible, slide up, if not slidedown.
         $expand.slideToggle(500, function () {
             //execute this after slideToggle is done
             //change text of header based on visibility of content div
+
+            // scrolls page to expanded slide
+            $('html, body').animate({
+                scrollTop: 1000
+            }, 500);
+            
         });
 
     });
+    $("a[href='" + window.location.hash + "']").parent(".studentinfo").click();
+    
+    
 });
 </script>
 
@@ -386,7 +395,7 @@ $("document").ready(function(){
   <div class="student_logins">
     <div class="header">
 
-      <p class="studentinfo">student{{number}} - Click to see login details</p>
+      <p class="studentinfo"><a href="#student{{number}}"></a>student{{number}} - Click to see login details</p>
     </div>
     <div class="content">
 {% for host in ansible_node_facts.instances %}


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In an effort to start implementing #750

I made edits to the jquery script in the website template to allow linking to a specific student number, scrolling the page to the proper student section and expanding the section to reveal the creds. To test, you have to append the path to the index file on the s3 page and then reference the anchor for the particular student number. 
**example:** `http://s3-mod-32020.rhdemo.io/s3-mod-32020-index.html#student1`

This will allow us to put a form in front of the workshop prompting for email address and on submission, redirecting to this page with the proper student number for that individual. Saves from throwing out the existing workshop page in order to implement that feature. 

![IMG_0429](https://user-images.githubusercontent.com/8515817/77193700-0d1f4780-6ab5-11ea-86ef-92a5516e40e2.gif)


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

