### PR TITLE
remove systemd task

### DIFF
--- a/provisioner/roles/common/tasks/main.yml
+++ b/provisioner/roles/common/tasks/main.yml
@@ -17,12 +17,6 @@
 - hostname:
     name: "{{short_name}}"
 
-- name: Update systemd
-  yum:
-    name: systemd*
-    state: latest
-    update_cache: true
-
 - meta: flush_handlers
   tags:
     - common


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This task was breaking deploys for whatever reason and is no longer needed on RHEL 8.
```
TASK [common : Update systemd] ***********************************************************************************************************************************
fatal: [win4320-student2-ansible]: FAILED! => changed=false
  ansible_facts:
    pkg_mgr: dnf
  failures: []
  msg: |-
    Depsolve Error occured:
     Problem: The operation would result in removing the following protected packages: systemd-udev
  rc: 1
  results: []
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
