### PR TITLE
Fix security workshop deployment

### DIFF
--- a/provisioner/roles/windows_ws_setup/tasks/smartconsole.yml
+++ b/provisioner/roles/windows_ws_setup/tasks/smartconsole.yml
@@ -7,6 +7,14 @@
         - vcredist2012
       state: present
 
+  - name: Set strong cryptography on 64 bit .Net Framework (version 4 and above)
+    win_shell: >
+      Set-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord
+
+  - name: Set strong cryptography on 32 bit .Net Framework (version 4 and above)
+    win_shell: >
+      Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\.NetFramework\v4.0.30319' -Name 'SchUseStrongCrypto' -Value '1' -Type DWord
+
   - name: Ensure the required NuGet package provider version is installed
     win_shell: Find-PackageProvider -Name Nuget -ForceBootstrap -IncludeDependencies -Force
 


### PR DESCRIPTION

##### SUMMARY

Security workshop deployment fails currently due to PackageProvider problems. This fixes it.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner

##### ADDITIONAL INFORMATION

Current deployments (and tests) fail with this error:

```
Find-PackageProvider : No match was found for the specified search criteria and package name 'Nuget'. Try
    Get-PackageSource to see all available registered package sources.
```

In my understanding dot net reaches out to servers which have strong encryption activated, and dotnet has not, thus download fails.
This PR activates the strong encryption thanks to [this thread](https://answers.microsoft.com/en-us/windows/forum/windows_7-performance/trying-to-install-program-using-powershell-and/4c3ac2b2-ebd4-4b2a-a673-e283827da143) on answers.microsoft.com. Tested, deploys now.