### PR TITLE
Syntax cleanup and new internal dns removal code

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -179,8 +179,8 @@
   roles:
     - role: internal_dns
       when:
-      - create_internal_dns is defined
-      - create_internal_dns
+        - create_internal_dns is defined
+        - create_internal_dns
 
 - name: configure ansible control node
   hosts: control_nodes
@@ -220,7 +220,7 @@
         value: "{{ ansible_host }}"
       when:
       - workshop_type == "advanced_tower"
-  #tags: tower_master
+      # tags: tower_master
 
 - name: Setup Amazon S3 Website for Student Login
   hosts: localhost

--- a/provisioner/roles/aws_dns_clusternodes/tasks/create.yml
+++ b/provisioner/roles/aws_dns_clusternodes/tasks/create.yml
@@ -16,3 +16,4 @@
   when:
     - towerinstall|bool
     - route53_status is not failed
+

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -467,7 +467,7 @@ To login to the Ansible Control Node use the following for SSH access:<br>
 <pre><code>ssh student{{number}}@{{ host.public_ip_address }}</code></pre>
 {% if dns_type != 'none' %}
 DNS: student{{number}}-ansible.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
-<pre><code>ssh student{{number}}@student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}</code></pre>
+<pre><code>ssh student{{number}}@student{{number}}-ansible.{{ec2_name_prefix}}.{{workshop_dns_zone}}</code></pre>
 {% endif %}
 </div>
 </div>

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -466,7 +466,7 @@ To login to the Ansible Control Node use the following for SSH access:<br>
 <div id="example_login">
 <pre><code>ssh student{{number}}@{{ host.public_ip_address }}</code></pre>
 {% if dns_type != 'none' %}
-DNS: student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
+DNS: student{{number}}-ansible.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
 <pre><code>ssh student{{number}}@student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}</code></pre>
 {% endif %}
 </div>

--- a/provisioner/roles/control_node/tasks/advanced_tower.yml
+++ b/provisioner/roles/control_node/tasks/advanced_tower.yml
@@ -2,3 +2,4 @@
 - name: advanced tower specific tasks
   debug:
     msg: nothing to do
+

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -1,41 +1,34 @@
 [tower]
-{% for host in hostvars %}
-{% if "tower_nodes" in hostvars[host].group_names %}
-{% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
-{% endif %}
-{% endif %}
+{% for host in groups.tower_nodes %}
+{%   if username == hostvars[host].username %}
+{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}
+{%   endif %}
 {% endfor %}
 
 [database]
-{% for host in hostvars %}
-{% if "towerdb" in hostvars[host].group_names %}
-{% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
-{% endif %}
-{% endif %}
+{% for host in groups.towerdb %}
+{%   if username == hostvars[host].username %}
+{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}
+{%   endif %}
 {% endfor %}
 
 [all:vars]
-admin_password='{{admin_password}}'
+ansible_user='{{ username }}'
+ansible_become=true
+admin_password='{{ admin_password }}'
+ansible_password='{{ admin_password }}'
 
-{% for host in hostvars %}
-{% if "towerdb" in hostvars[host].group_names %}
-{% if username in hostvars[host].inventory_hostname %}
-pg_host='{{ hostvars[host].ansible_host }}'
-{% endif %}
-{% endif %}
-{% endfor %}
+pg_host='{{ username }}-towerdb.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}'
 pg_port='5432'
 
 pg_database='awx'
 pg_username='awx'
-pg_password='{{admin_password}}'
+pg_password='{{ admin_password }}'
 
 rabbitmq_port=5672
 rabbitmq_vhost=tower
 rabbitmq_username=tower
-rabbitmq_password='{{admin_password}}'
+rabbitmq_password='{{ admin_password }}'
 rabbitmq_cookie=cookiemonster
 
 # Needs to be true for fqdns and ip addresses

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -35,4 +35,5 @@ rabbitmq_cookie=cookiemonster
 rabbitmq_use_long_name=true
 
 gpgcheck='{{ gpgcheck | default(1)}}'
-aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'
+
+# aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'

--- a/provisioner/roles/internal_dns/tasks/create.yml
+++ b/provisioner/roles/internal_dns/tasks/create.yml
@@ -6,17 +6,17 @@
     vpc_id: "{{ vpc_id }}"
     vpc_region: "{{ vpc_region }}"
   delegate_to: localhost
-  run_once: True
+  run_once: true
 
 - name: create internal DNS records
   become: false
   route53:
     state: present
     zone: "{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}"
-    private_zone: yes
+    private_zone: true
     record: "{{ record }}"
     type: "{{ type }}"
     overwrite: true
     value: "{{ value }}"
-    wait: yes
+    wait: true
   delegate_to: localhost

--- a/provisioner/roles/internal_dns/tasks/main.yml
+++ b/provisioner/roles/internal_dns/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: create private DNS zone 
+- name: create private DNS zone
   include_tasks: create.yml
   when:
   - not teardown

--- a/provisioner/roles/internal_dns/tasks/remove.yml
+++ b/provisioner/roles/internal_dns/tasks/remove.yml
@@ -1,17 +1,37 @@
 ---
-- name: Get all hosted zones
-  route53_info:
-    query: hosted_zone
-  register: hosted_zones
+- name: Output debug info for Route53
+  debug:
+    msg:
+      - "Internal DNS Zone: {{ ec2_name_prefix }} {{ workshop_internal_dns_zone }}"
+      - "AWS_PROFILE:  {{ lookup('env','AWS_PROFILE') }}"
+    verbosity: 2
 
-- debug:
-    msg: "{{ ec2_name_prefix }} {{ workshop_internal_dns_zone }}"
+- name: route53_info by aws cli
+  command: >-
+    aws route53 list-hosted-zones-by-name
+      --dns-name {{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}
+      --region {{ ec2_region }}
+      --profile {{ AWS_PROFILE }}
+  register: r_zone_info
+  vars:
+    AWS_PROFILE: "{{ lookup('env','AWS_PROFILE') }}"
 
-- name: Get zone id for zone {{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}
+- name: Set zone_info easy parse fact
   set_fact:
-    privatezoneid: "{{ item.Id | regex_replace('\/hostedzone\/', '') }}"
-  loop: "{{ hosted_zones.HostedZones }}"
-  when: item.Name == ec2_name_prefix + "." + workshop_internal_dns_zone + "."
+    f_zone_info_json: "{{ r_zone_info.stdout | from_json }}"
+
+- when: hosted_zone.Name == ec2_name_prefix + "." + workshop_internal_dns_zone + "."
+  name: Output Hostedzone id
+  set_fact:
+    privatezoneid: "{{ hosted_zone.Id | regex_replace('\/hostedzone\/', '') }}"
+  loop: "{{ f_zone_info_json.HostedZones }}"
+  loop_control:
+    loop_var: hosted_zone
+
+- name: Output privatezoneid for debugging
+  debug:
+    msg: "privatezoneid: {{ privatezoneid }}"
+    verbosity: 2
 
 - name: Get A records for zone {{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}
   route53_info:
@@ -38,3 +58,4 @@
     zone: "{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}"
     vpc_id: "{{ ec2_vpc_id }}"
     vpc_region: "{{ ec2_region }}"
+

--- a/provisioner/sample_workshops/sample-vars-adv-tower.yml
+++ b/provisioner/sample_workshops/sample-vars-adv-tower.yml
@@ -31,7 +31,7 @@ towerinstall: true
 # Sets the Route53 DNS zone to use for the S3 website
 workshop_dns_zone: "rhdemo.io"
 
-## Internal DNS only for RHEL and Advanced Tower 
+## Internal DNS only for RHEL and Advanced Tower
 # Create internal zone ec2_name_prefix.workshop_internal_dns_zone
 create_internal_dns: true
 # Name of internal DNS zone


### PR DESCRIPTION
Not submitted to devel, 1 off Event branch PR for advanced-tower

##### SUMMARY
Fixes an internal DNS issue and cleans up syntax for Zuul in other role/task files etc

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
-

##### ADDITIONAL INFORMATION
On GPTE region route53_info fails to return private hosted zones leading to artifacts being left behind in route53. This workaround but achieving the desired functionality via command and the was cli