### PR TITLE
WIP: disable internal_dns

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -166,21 +166,21 @@
     - user_accounts
     - common
 
-- name: Configure internal DNS
-  hosts: managed_nodes
-  become: true
-  gather_facts: false
-  vars:
-    vpc_id: "{{ hostvars['localhost']['create_vpc']['vpc']['id'] }}"
-    vpc_region: "{{ hostvars['localhost']['ec2_region'] }}"
-    record: "{{username}}-{{ ansible_nodename }}.{{ec2_name_prefix|lower}}.{{ workshop_internal_dns_zone }}"
-    type: "A"
-    value: "{{ private_ip }}"
-  roles:
-    - role: internal_dns
-      when:
-      - create_internal_dns is defined
-      - create_internal_dns
+# - name: Configure internal DNS
+#   hosts: managed_nodes
+#   become: true
+#   gather_facts: false
+#   vars:
+#     vpc_id: "{{ hostvars['localhost']['create_vpc']['vpc']['id'] }}"
+#     vpc_region: "{{ hostvars['localhost']['ec2_region'] }}"
+#     record: "{{username}}-{{ ansible_nodename }}.{{ec2_name_prefix|lower}}.{{ workshop_internal_dns_zone }}"
+#     type: "A"
+#     value: "{{ private_ip }}"
+#   roles:
+#     - role: internal_dns
+#       when:
+#       - create_internal_dns is defined
+#       - create_internal_dns
 
 - name: configure ansible control node
   hosts: control_nodes

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -479,11 +479,12 @@ DNS: student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
 To login to the Ansible Tower UI use the following credentials:<br>
 <table>
 {% if dns_type != 'none' %}
+{% if workshop_type != 'advanced_tower' %}
   <tr>
 <td>UI link:</td>
 <td><a target=_blank href="https://student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}">https://student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}</a></td>
   </tr>
-{% endif %}
+{% endif %}{% endif %}
 {% if workshop_type == 'advanced_tower' %}
   <tr>
 <td>Tower Cluster Nodes:</td>

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -466,8 +466,8 @@ To login to the Ansible Control Node use the following for SSH access:<br>
 <div id="example_login">
 <pre><code>ssh student{{number}}@{{ host.public_ip_address }}</code></pre>
 {% if dns_type != 'none' %}
-DNS: student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
-<pre><code>ssh student{{number}}@student{{number}}.{{ec2_name_prefix}}.{{workshop_dns_zone}}</code></pre>
+DNS: student{{number}}-ansible.{{ec2_name_prefix}}.{{workshop_dns_zone}}<br>
+<pre><code>ssh student{{number}}@student{{number}}-ansible.{{ec2_name_prefix}}.{{workshop_dns_zone}}</code></pre>
 {% endif %}
 </div>
 </div>

--- a/provisioner/roles/common/tasks/main.yml
+++ b/provisioner/roles/common/tasks/main.yml
@@ -59,3 +59,11 @@
 - meta: flush_handlers
   tags:
     - common
+
+- name: setup /etc/hosts file per student
+  copy:
+    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
+    dest: "/etc/hosts"
+    owner: root
+    group: root
+    mode: 0644

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -14,6 +14,10 @@
     remote_src: true
     extra_opts: ['--strip-components=1', '--show-stored-names']
 
+- name: print debug output
+  debug:
+    var: hostvars
+
 - name: template inventory file for Ansible Tower Install
   template:
     src: tower_install.j2

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -14,10 +14,6 @@
     remote_src: true
     extra_opts: ['--strip-components=1', '--show-stored-names']
 
-- name: print debug output
-  debug:
-    var: hostvars
-
 - name: template inventory file for Ansible Tower Install
   template:
     src: tower_install.j2

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -2,7 +2,7 @@
 {% for host in hostvars %}
 {% if "tower_nodes" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].ansible_host }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -11,7 +11,7 @@
 {% for host in hostvars %}
 {% if "towerdb" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ username }}-{{ hostvars[host].ansible_nodename }}.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].ansible_host }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -1,41 +1,39 @@
 [tower]
-{% for host in hostvars %}
-{% if "tower_nodes" in hostvars[host].group_names %}
-{% if username in hostvars[host].inventory_hostname %}
+{% for host in groups.tower_nodes %}
+{%   if username == hostvars[host].username %}
 {{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
-{% endif %}
-{% endif %}
+{%   endif %}
 {% endfor %}
 
 [database]
-{% for host in hostvars %}
-{% if "towerdb" in hostvars[host].group_names %}
-{% if username in hostvars[host].inventory_hostname %}
+{% for host in groups.towerdb %}
+{%   if username == hostvars[host].username %}
 {{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
-{% endif %}
-{% endif %}
+{%   endif %}
 {% endfor %}
 
 [all:vars]
-admin_password='{{admin_password}}'
+ansible_user='{{ username }}'
+ansible_become=true
+admin_password='{{ admin_password }}'
+ansible_password='{{ admin_password }}'
 
-{% for host in hostvars %}
-{% if "towerdb" in hostvars[host].group_names %}
+{% for host in groups.towerdb %}
 {% if username in hostvars[host].inventory_hostname %}
-pg_host='{{ hostvars[host].ansible_host }}'
-{% endif %}
+pg_host='{{ username }}-towerdb.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}'
 {% endif %}
 {% endfor %}
+
 pg_port='5432'
 
 pg_database='awx'
 pg_username='awx'
-pg_password='{{admin_password}}'
+pg_password='{{ admin_password }}'
 
 rabbitmq_port=5672
 rabbitmq_vhost=tower
 rabbitmq_username=tower
-rabbitmq_password='{{admin_password}}'
+rabbitmq_password='{{ admin_password }}'
 rabbitmq_cookie=cookiemonster
 
 # Needs to be true for fqdns and ip addresses

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -2,7 +2,7 @@
 {% for host in hostvars %}
 {% if "tower_nodes" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -11,7 +11,7 @@
 {% for host in hostvars %}
 {% if "towerdb" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }}.{{ workshop_internal_dns_zone }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -2,7 +2,7 @@
 {% for host in hostvars %}
 {% if "tower_nodes" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].ansible_host }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -11,7 +11,7 @@
 {% for host in hostvars %}
 {% if "towerdb" in hostvars[host].group_names %}
 {% if username in hostvars[host].inventory_hostname %}
-{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].ansible_host }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
+{{ hostvars[host].ansible_nodename }} ansible_host={{ hostvars[host].short_name }} ansible_user="{{ username }}" ansible_password='{{ admin_password }}' ansible_become=true
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/control_node/templates/advanced_tower_install.j2
+++ b/provisioner/roles/control_node/templates/advanced_tower_install.j2
@@ -20,7 +20,7 @@ ansible_password='{{ admin_password }}'
 
 {% for host in groups.towerdb %}
 {% if username in hostvars[host].inventory_hostname %}
-pg_host='{{ username }}-towerdb.{{ ec2_name_prefix }}.{{ workshop_internal_dns_zone }}'
+pg_host='{{ hostvars[host].short_name }}.{{ workshop_internal_dns_zone }}'
 {% endif %}
 {% endfor %}
 

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_advanced_tower.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_advanced_tower.j2
@@ -3,54 +3,54 @@
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in isonode_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in remote_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in towernode1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in towernode2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in towernode3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in towerdb_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_devops.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_devops.j2
@@ -3,30 +3,30 @@
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node4_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_f5.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_f5.j2
@@ -3,24 +3,24 @@
 
 {% for vm in f5_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_networking.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_networking.j2
@@ -3,26 +3,26 @@
 
 {% for vm in rtr1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% for vm in rtr2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% for vm in rtr3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% for vm in rtr4_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_rhel.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_rhel.j2
@@ -3,24 +3,24 @@
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_security.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_security.j2
@@ -3,42 +3,42 @@
 
 {% for vm in windows_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in qradar_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in attacker_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in checkpoint_gw_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in checkpoint_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in snort_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.public_ip_address }} {{vm.tags.short_name}} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts_windows.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts_windows.j2
@@ -4,7 +4,7 @@
 {% if instance1_node_facts.instances is defined %}
 {% for vm in instance1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -13,18 +13,18 @@
 {% if instance2_node_facts.instances is defined %}
 {% for vm in instance2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}
 
 {% for vm in gitlab_node_facts.instances %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endfor %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.public_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }} {{ vm.tags.short_name }}.{{ workshop_internal_dns_zone }}
 {% endif %}
 {% endfor %}

--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -18,7 +18,7 @@
     - {include_role: {name: aws_dns}, when: create_login_page is defined and create_login_page}
     - {include_role: {name: code_server}, when: code_server}
     - {include_role: {name: gitlab-server}, when: workshop_type == "windows"}
-    - {include_role: {name: internal_dns}, when: create_internal_dns is defined and create_internal_dns}
+    #- {include_role: {name: internal_dns}, when: create_internal_dns is defined and create_internal_dns}
     - {include_role: {name: aws_dns_clusternodes}, when: workshop_type == "advanced_tower"}
 
     - name: Remove workshop local files


### PR DESCRIPTION
#### SUMMARY
We're facing stability issues with the route53 module. Due to time constraints we disable the internal_dns role.

This PR disables the role and uses the short name for the Ansible Tower inventory. It also creates /etc/hosts on all instances to provide a simple name resolution method for the students.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
