### PR TITLE
adding IBM Community grid into idle time

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -96,6 +96,17 @@
         - towerinstall|bool
         - populatetower
 
+- name: IBM community grid
+  hosts: "control_nodes:managed_nodes"
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: install boinc-client and register
+      include_role:
+        name: community_grid
+
+
 - name: include workshop_type unique setup roles
   import_playbook: "{{workshop_type}}.yml"
 

--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install EPEL
+  dnf:
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+    state: present
+
+- package:
+    name:
+      - boinc-client
+    state: present
+
+- name: enable and start boinc-client
+  systemd:
+    name: boinc-client
+    state: started
+    enabled: yes
+
+- name: World Community Grid
+  vars:
+     boinc_auth: "1fa4185037ba9ff7b01be35ef286c547"
+     boinc_url: "www.worldcommunitygrid.org"
+  command:
+    cmd: "boinccmd --project_attach {{boinc_url}} {{boinc_auth}}"
+    chdir: /var/lib/boinc/
+    creates: "/var/lib/boinc/account_{{ boinc_url }}.xml"


### PR DESCRIPTION
##### SUMMARY
a lot of workshops sit idle for 24 hours or more, we are going to use CPU idle time to help stop COVID-19, crush childhood cancer, etc that the IBM community grid project is helping solve with CPU idle cycles

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION



![image](https://user-images.githubusercontent.com/6537680/81175847-3a935800-8f72-11ea-8bd7-29090b0442a1.png)
