### PR TITLE
Fix Windows Workshop Instance 2 Tag / VM Name

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/instances/instances_windows.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances/instances_windows.yml
@@ -54,10 +54,10 @@
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     count_tag:
-      Workshop_instance1: "{{ ec2_name_prefix }}-instance1"
+      Workshop_instance2: "{{ ec2_name_prefix }}-instance2"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
-    user_data: "{{ lookup('template', 'skylight_windows_userdata.j2', template_vars=dict(vm_name='instance1')) }}"
+    user_data: "{{ lookup('template', 'skylight_windows_userdata.j2', template_vars=dict(vm_name='instance2')) }}"
   register: instance2_output
   when: doubleup|bool
 


### PR DESCRIPTION
##### SUMMARY
In the Windows Workshop, the creation of Instance 2 was copy and pasted from the tasks of Instance 1, and the Tags and VM Name were not properly updated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
Doesn't affect provisioning of the VM Itself, since we don't modify these hosts at all after creation.  It is also unaffected during provisioning because we aren't properly tagging with instance tags between or during ec2 calls (2 x ec2 calls back to back, using the same count_tag will still provision since the tag doesn't exist on the host at the time of the 2nd ec2 call).  I will create a separate PR to handle that, as we need to apply it to more than just the Windows Workshop.

This does affect the ability for ec2_instance_info to properly though if we ever decide to make modifications to these hosts.