### PR TITLE
Fix linting issues in community_grid role

### DIFF
--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -13,12 +13,12 @@
   systemd:
     name: boinc-client
     state: started
-    enabled: yes
+    enabled: true
 
 - name: World Community Grid
   vars:
-     boinc_auth: "1fa4185037ba9ff7b01be35ef286c547"
-     boinc_url: "www.worldcommunitygrid.org"
+    boinc_auth: "1fa4185037ba9ff7b01be35ef286c547"
+    boinc_url: "www.worldcommunitygrid.org"
   command:
     cmd: "boinccmd --project_attach {{boinc_url}} {{boinc_auth}}"
     chdir: /var/lib/boinc/


### PR DESCRIPTION
##### SUMMARY
All PRs are failing linting because of an already merged linting error in the community_grid role.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
```
./provisioner/roles/community_grid/tasks/main.yml
  16:14     warning  truthy value should be one of [false, true]  (truthy)
  20:6      error    wrong indentation: expected 4 but found 5  (indentation)
```
