### PR TITLE
attempt 2 for IBM Community Grid update

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -71,6 +71,9 @@ towerinstall: true
 
 # automatically licenses Tower if license is provided
 autolicense: true
+
+# IBM Community Grid - defaults to true if you don't tell the provisioner
+ibm_community_grid: false
 ```
 
 If you want to license it you must copy a license called tower_license.json into this directory.  If you do not have a license already please request one using the [Workshop License Link](https://www.ansible.com/workshop-license).

--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -35,3 +35,4 @@ security_console: qradar
 valid_security_console_types:
   - splunk
   - qradar
+ibm_community_grid: true

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -115,7 +115,7 @@
         - populatetower
 
 - name: IBM community grid
-  hosts: "control_nodes:managed_nodes"
+  hosts: "managed_nodes"
   become: true
   gather_facts: false
 
@@ -123,6 +123,9 @@
     - name: install boinc-client and register
       include_role:
         name: community_grid
+      when:
+        - ibm_community_grid is defined
+        - ibm_community_grid
 
 
 - name: include workshop_type unique setup roles

--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -4,7 +4,8 @@
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
 
-- package:
+- name: install boinc-client with package module
+  package:
     name:
       - boinc-client
     state: present

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -51,10 +51,13 @@
 
 - name: make sure .ssh is created
   file:
-    path: "/home/{{username}}/.ssh/"
+    path: "/home/{{item}}/.ssh/"
     owner: "{{ username }}"
     group: "{{ username }}"
     state: directory
+  loop:
+    - "{{ansible_user}}"
+    - "{{username}}"
 
 - name: copy over ssh config file
   template:

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -51,13 +51,10 @@
 
 - name: make sure .ssh is created
   file:
-    path: "/home/{{item}}/.ssh/"
+    path: "/home/{{username}}/.ssh/"
     owner: "{{ username }}"
     group: "{{ username }}"
     state: directory
-  loop:
-    - "{{ansible_user}}"
-    - "{{username}}"
 
 - name: copy over ssh config file
   template:

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -26,17 +26,6 @@
   async: 1400
   poll: 15
 
-- name: install ansible-tower-cli and requests
-  become: true
-  pip:
-    name:
-      - ansible-tower-cli
-      - "requests==2.6.0"
-    state: latest
-  register: pip_install
-  until: pip_install is not failed
-  retries: 5
-
 - name: wait for Ansible Tower to be up
   uri:
     url: https://localhost/api/v2/ping/
@@ -52,6 +41,14 @@
 - name: Display /api/v2/ping results
   debug:
     msg: '{{ check2.json }}'
+
+- name: install ansible-tower-cli and requests
+  become: true
+  pip:
+    name:
+      - ansible-tower-cli
+      - "requests==2.6.0"
+    state: latest
 
 # This is documented here: https://docs.ansible.com/ansible-tower/latest/html/upgrade-migration-guide/virtualenv.html#preparing-a-new-custom-virtualenv
 - name: Create directory for custom venvs

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -33,6 +33,9 @@
       - ansible-tower-cli
       - "requests==2.6.0"
     state: latest
+  register: pip_install
+  until: pip_install is not failed
+  retries: 5
 
 - name: wait for Ansible Tower to be up
   uri:


### PR DESCRIPTION
### SUMMARY

- making community grid optional (but defaults on) using the `ibm_community_grid` variable (default set to true`
- only install on auxiliary hosts, not where Ansible Tower is installed

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
discussion with @cigamit brought up some concerns, everything works fine but we don't want ansible to seem slow... and it would require additional work on the control node to be smart about it... not sure ROI when we have additional servers that sit there for the duration of lab that can crunch through community grid data all day long
