### PR TITLE
make attendance feature on by default

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -61,7 +61,8 @@ dns_type: aws
 admin_password: your_password123
 
 # creates AWS S3 website for ec2_name_prefix.workshop_dns_zone
-create_login_page: true
+# this is defaulted to on as of May 13th, 2020
+create_login_page: false
 
 # Sets the Route53 DNS zone to use for the S3 website
 workshop_dns_zone: rhdemo.io
@@ -100,7 +101,7 @@ For more extra_vars examples, look at the following:
   - Workbench information is stored in two places after you provision:
     1. in a local directory named after the workshop (e.g. testworkshop/instructor_inventory)
 
-    2. if `create_login_page: true` is enabled in your `extra_vars file,` there will be a website `ec2_name_prefix.workshop_dns_zone` (e.g. `testworkshop.rhdemo.io`)
+    2. By default there will be a website `ec2_name_prefix.workshop_dns_zone` (e.g. `testworkshop.rhdemo.io`)
 
        - **NOTE:** It is possible to change the DNS domain (right now this is only supported via a AWS Route 53 Hosted Zone) using the parameter `workshop_dns_zone` in your `extra_vars.yml` file.
 

--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -30,7 +30,8 @@ valid_network_types:
   - juniper
   - multivendor
 doubleup: false
-attendance: false
+create_login_page: true
+attendance: true
 security_console: qradar
 valid_security_console_types:
   - splunk

--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -7,6 +7,7 @@ teardown: false
 towerinstall: false
 populatetower: true
 website_information: ""
+login_website_information: ""
 dns_information: "No errors with DNS"
 callback_information: "No issue with Ansible Tower callback"
 workshop_type: ""

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -163,8 +163,8 @@
           - Workshop name is {{ec2_name_prefix}}
           - Instructor inventory is located at  {{playbook_dir}}/{{ec2_name_prefix}}/instructor_inventory.txt
           - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem
-          {{website_information}}
-          {{hostvars['attendance-host'].login_website_information}}
+          - {{website_information}}
+          - {{hostvars['attendance-host'].login_website_information}}
 
           FAILURES
           *******************

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -30,12 +30,6 @@
     - role: workshop_attendance_nginx
       when:
         - attendance|bool
-
-- name: Configure attendance host
-  hosts: attendance
-  become: true
-  gather_facts: true
-  roles:
     - role: workshop_attendance
       when:
         - attendance|bool
@@ -158,7 +152,7 @@
 - name: print out information for instructor
   hosts: localhost
   connection: local
-  become: false
+  become:
   gather_facts: false
   tasks:
     - name: set facts for output
@@ -170,6 +164,8 @@
           - Instructor inventory is located at  {{playbook_dir}}/{{ec2_name_prefix}}/instructor_inventory.txt
           - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem
           {{website_information}}
+          {{hostvars['attendance-host'].login_website_information}}
+
           FAILURES
           *******************
           {{dns_information}}

--- a/provisioner/roles/aws_workshop_login_page/tasks/main.yml
+++ b/provisioner/roles/aws_workshop_login_page/tasks/main.yml
@@ -63,13 +63,11 @@
 
     - name: SET WEBSITE INFORMATION VARIABLE
       set_fact:
-        website_information: |
-          - Website created at http://{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}
+        website_information: "Website created at http://{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}"
   rescue:
     - debug:
         msg: 'issue with S3 website'
 
     - name: provide error information
       set_fact:
-        dns_information: |
-          - aws_workshop_login_page role hit an issue
+        dns_information: "aws_workshop_login_page role hit an issue"

--- a/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
+++ b/provisioner/roles/aws_workshop_login_page/templates/index.html.j2
@@ -388,8 +388,16 @@ $("document").ready(function(){
         </div>
     </div>
 </section>
-
-
+{% if attendance %}
+<div class="attendance">
+<section>
+  <div class="container">
+  Not sure which workbench you are assigned to?  Please go here:
+  <a href="http://login.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}">http://login.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}</a>
+  </div>
+</section>
+</div>
+{% endif %}
 <section>
     <div class="container">
         <div class="row">

--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -1,26 +1,31 @@
 ---
-- name: Install EPEL
-  dnf:
-    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-    state: present
+- name: initiation boinc-client installation and registration
+  block:
+    - name: Install EPEL
+      dnf:
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
+        state: present
 
-- name: install boinc-client with package module
-  package:
-    name:
-      - boinc-client
-    state: present
+    - name: install boinc-client with package module
+      package:
+        name:
+          - boinc-client
+        state: present
 
-- name: enable and start boinc-client
-  systemd:
-    name: boinc-client
-    state: started
-    enabled: true
+    - name: enable and start boinc-client
+      systemd:
+        name: boinc-client
+        state: started
+        enabled: true
 
-- name: World Community Grid
-  vars:
-    boinc_auth: "1fa4185037ba9ff7b01be35ef286c547"
-    boinc_url: "www.worldcommunitygrid.org"
-  command:
-    cmd: "boinccmd --project_attach {{boinc_url}} {{boinc_auth}}"
-    chdir: /var/lib/boinc/
-    creates: "/var/lib/boinc/account_{{ boinc_url }}.xml"
+    - name: World Community Grid
+      vars:
+        boinc_auth: "1fa4185037ba9ff7b01be35ef286c547"
+        boinc_url: "www.worldcommunitygrid.org"
+      command:
+        cmd: "boinccmd --project_attach {{boinc_url}} {{boinc_auth}}"
+        chdir: /var/lib/boinc/
+        creates: "/var/lib/boinc/account_{{ boinc_url }}.xml"
+  rescue:
+    - debug:
+        msg: 'community grid role has failed, continuing workshop'

--- a/provisioner/roles/workshop_attendance/tasks/main.yml
+++ b/provisioner/roles/workshop_attendance/tasks/main.yml
@@ -13,13 +13,6 @@
 
 - name: set information for instructor
   set_fact:
-    login_website_information: |
-      - Auto-Assignment website located at http://login.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}
-  delegate_to: localhost
-  run_once: true
-
-- name: print website info
-  debug:
-    msg: "The auto-assignment website information is {{login_website_information}}"
+    login_website_information: "Auto-Assignment website located at http://login.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}"
   delegate_to: localhost
   run_once: true

--- a/provisioner/roles/workshop_attendance/tasks/main.yml
+++ b/provisioner/roles/workshop_attendance/tasks/main.yml
@@ -10,3 +10,16 @@
 - name: Configure attendance host
   import_tasks: attendance.yml
   when: not teardown
+
+- name: set information for instructor
+  set_fact:
+    login_website_information: |
+      - Auto-Assignment website located at http://login.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone|lower }}
+  delegate_to: localhost
+  run_once: true
+
+- name: print website info
+  debug:
+    msg: "The auto-assignment website information is {{login_website_information}}"
+  delegate_to: localhost
+  run_once: true

--- a/provisioner/sample_workshops/sample-arista.yml
+++ b/provisioner/sample_workshops/sample-arista.yml
@@ -10,4 +10,3 @@ workshop_type: network
 network_type: arista
 ## Optional Variables
 dns_type: aws
-create_login_page: true

--- a/provisioner/sample_workshops/sample-cisco.yml
+++ b/provisioner/sample_workshops/sample-cisco.yml
@@ -10,4 +10,3 @@ workshop_type: network
 network_type: cisco
 ## Optional Variables
 dns_type: aws
-create_login_page: true

--- a/provisioner/sample_workshops/sample-juniper.yml
+++ b/provisioner/sample_workshops/sample-juniper.yml
@@ -9,4 +9,3 @@ workshop_type: network
 network_type: juniper
 ## Optional Variables
 dns_type: aws
-create_login_page: true

--- a/provisioner/sample_workshops/sample-multivendor.yml
+++ b/provisioner/sample_workshops/sample-multivendor.yml
@@ -8,4 +8,3 @@ student_total: 2
 workshop_type: network
 ## Optional Variables
 dns_type: aws
-create_login_page: true

--- a/provisioner/sample_workshops/sample-vars-devops.yml
+++ b/provisioner/sample_workshops/sample-vars-devops.yml
@@ -11,4 +11,3 @@ admin_password: ansible
 workshop_dns_zone: redhatgov.io
 towerinstall: true
 # creates HTML website for workshop
-create_login_page: true

--- a/provisioner/sample_workshops/sample-vars-f5.yml
+++ b/provisioner/sample_workshops/sample-vars-f5.yml
@@ -12,5 +12,3 @@ workshop_type: f5
 admin_password: ansible
 # turn DNS on for control nodes, and set to type in valid_dns_type
 dns_type: aws
-# creates HTML website for workshop
-create_login_page: true

--- a/provisioner/sample_workshops/sample-vars-network.yml
+++ b/provisioner/sample_workshops/sample-vars-network.yml
@@ -13,4 +13,4 @@ admin_password: ansible
 # turn DNS on for control nodes, and set to type in valid_dns_type
 dns_type: aws
 # creates HTML website for workshop
-create_login_page: true
+create_login_page: false

--- a/provisioner/sample_workshops/sample-vars-rhel-90.yml
+++ b/provisioner/sample_workshops/sample-vars-rhel-90.yml
@@ -12,10 +12,6 @@ workshop_type: rhel_90
 admin_password: ansible
 # turn DNS on for control nodes, and set to type in valid_dns_type
 dns_type: aws
-# creates HTML website for workshop
-create_login_page: true
-# when towerinstall is on, this will license it with provided license
-autolicense: true
 # this will install Ansible Tower on all control nodes
 towerinstall: true
 # this will install all demos from github.com/ansible/product-demos that work for this workshop type

--- a/provisioner/sample_workshops/sample-vars-rhel.yml
+++ b/provisioner/sample_workshops/sample-vars-rhel.yml
@@ -12,7 +12,5 @@ workshop_type: rhel
 admin_password: ansible
 # turn DNS on for control nodes, and set to type in valid_dns_type
 dns_type: aws
-# creates HTML website for workshop
-create_login_page: true
 # this will install Ansible Tower on all control nodes
 towerinstall: true

--- a/provisioner/sample_workshops/sample-vars-windows.yml
+++ b/provisioner/sample_workshops/sample-vars-windows.yml
@@ -16,7 +16,5 @@ doubleup: false
 admin_password: ansible123
 # adds a form that prompts for name and email to allocate student credentials
 attendance: false
-# creates AWS S3 website for ec2_name_prefix.workshop_dns_zone
-create_login_page: true
 # automatically installs Tower to control node
 towerinstall: true


### PR DESCRIPTION
##### SUMMARY
i am making @cloin and @cigamit 's attendance feature on by default.  I added some additional info to the default webpage and to the provisioner summary.  It will look something like this->

```
TASK [Print Summary Information] **********************************************************************************************************************************************************************************************************
ok: [localhost] =>
  msg: |-
    PROVISIONER SUMMARY
    *******************
    - Workshop name is sean-may13-rhel
    - Instructor inventory is located at  /Users/sean/Documents/GitHub/IPvSean/workshops/provisioner/sean-may13-rhel/instructor_inventory.txt
    - Private key is located at /Users/sean/Documents/GitHub/IPvSean/workshops/provisioner/sean-may13-rhel/sean-may13-rhel-private.pem
    - Website created at http://sean-may13-rhel.rhdemo.io
    - Auto-Assignment website located at http://login.sean-may13-rhel.rhdemo.io

    FAILURES
    *******************
    No errors with DNS
    No issue with Ansible Tower callback
```

i am also making sure if boinc-client fails for community grid that it will not affect workshops

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
cc @goetzrieger @liquidat @ptoal 
