### PR TITLE
Exercise fixes on 1.7 and 2.2

### DIFF
--- a/exercises/ansible_rhel/1.7-role/README.es.md
+++ b/exercises/ansible_rhel/1.7-role/README.es.md
@@ -146,7 +146,7 @@ A continuación, agregamos dos tareas más para garantizar una estructura de dir
 - name: deliver html content
   copy:
     src: web.html
-    dest: "/var/www/vhosts/{{ ansible_hostname }}"
+    dest: "/var/www/vhosts/{{ ansible_hostname }}/index.html"
 ```
 <!-- {% endraw %} -->
 

--- a/exercises/ansible_rhel/1.7-role/README.fr.md
+++ b/exercises/ansible_rhel/1.7-role/README.fr.md
@@ -146,7 +146,7 @@ Ensuite, nous ajoutons deux tâches supplémentaires pour garantir une structure
 - name: deliver html content
   copy:
     src: web.html
-    dest: "/var/www/vhosts/{{ ansible_hostname }}"
+    dest: "/var/www/vhosts/{{ ansible_hostname }}/index.html"
 ```
 <!-- {% endraw %} -->
 

--- a/exercises/ansible_rhel/1.7-role/README.md
+++ b/exercises/ansible_rhel/1.7-role/README.md
@@ -148,7 +148,7 @@ Next we add two more tasks to ensure a vhost directory structure and copy html c
 - name: deliver html content
   copy:
     src: web.html
-    dest: "/var/www/vhosts/{{ ansible_hostname }}"
+    dest: "/var/www/vhosts/{{ ansible_hostname }}/index.html"
 ```
 <!-- {% endraw %} -->
 
@@ -225,7 +225,7 @@ Create the handler in the file `handlers/main.yml` to restart httpd when notifie
 
 Create the HTML content that will be served by the webserver.
 
-  - Create an web.html file in the "src" directory of the role, `files`:
+  - Create the `web.html` file in the "src" directory of the role, `files`:
 
 ```bash
 [student<X>@ansible ansible-files]$ echo 'simple vhost index' > ~/ansible-files/roles/apache_vhost/files/web.html

--- a/exercises/ansible_rhel/2.2-cred/README.es.md
+++ b/exercises/ansible_rhel/2.2-cred/README.es.md
@@ -100,10 +100,10 @@ También es posible ejecutar comandos ad hoc desde Ansible Tower.
     </tr>
     <tr>
       <td>MODULE</td>
-      <td>MACHINE CREDENTIAL</td>
+      <td>ping</td>
     </tr>
     <tr>
-      <td>ping</td>
+      <td>MACHINE CREDENTIAL</td>
       <td>Workshop Credentials</td>
     </tr>
   </table>

--- a/exercises/ansible_rhel/2.2-cred/README.fr.md
+++ b/exercises/ansible_rhel/2.2-cred/README.fr.md
@@ -101,10 +101,10 @@ Il est également possible d'exécuter des commandes ad hoc à partir d'Ansible 
     </tr>
     <tr>
       <td>MODULE</td>
-      <td>MACHINE CREDENTIAL</td>
+      <td>ping</td>
     </tr>
     <tr>
-      <td>ping</td>
+      <td>MACHINE CREDENTIAL</td>
       <td>Workshop Credentials</td>
     </tr>
   </table>

--- a/exercises/ansible_rhel/2.2-cred/README.md
+++ b/exercises/ansible_rhel/2.2-cred/README.md
@@ -96,10 +96,10 @@ It is possible to run run ad hoc commands from Ansible Tower as well.
     </tr>
     <tr>
       <td>MODULE</td>
-      <td>MACHINE CREDENTIAL</td>
+      <td>ping</td>
     </tr>
     <tr>
-      <td>ping</td>
+      <td>MACHINE CREDENTIAL</td>
       <td>Workshop Credentials</td>
     </tr>
   </table>


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Clarified the exercise code on 1.7. Originally it would copy the `web.html` and when students would do a curl it would fail. So added a rename to `index.html` so the file will be the index file for the Apache server. Also fixed a small typo.

Fixed a broken table on exercise 2.2. The Module and Value fields were messed up.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
