### PR TITLE
adding override for ibm community grid

### DIFF
--- a/exercises/ansible_f5/turn_off_community_grid.yml
+++ b/exercises/ansible_f5/turn_off_community_grid.yml
@@ -1,0 +1,11 @@
+---
+- name: turn off community-grid
+  hosts: web
+  gather_facts: false
+  become: yes
+  tasks:
+    - name: enable and start boinc-client
+      systemd:
+        name: boinc-client
+        state: stopped
+        enabled: false

--- a/exercises/ansible_rhel/turn_off_community_grid.yml
+++ b/exercises/ansible_rhel/turn_off_community_grid.yml
@@ -1,0 +1,11 @@
+---
+- name: turn off community-grid
+  hosts: web
+  gather_facts: false
+  become: yes
+  tasks:
+    - name: enable and start boinc-client
+      systemd:
+        name: boinc-client
+        state: stopped
+        enabled: false

--- a/exercises/ansible_rhel_90/turn_off_community_grid.yml
+++ b/exercises/ansible_rhel_90/turn_off_community_grid.yml
@@ -1,0 +1,11 @@
+---
+- name: turn off community-grid
+  hosts: web
+  gather_facts: false
+  become: yes
+  tasks:
+    - name: enable and start boinc-client
+      systemd:
+        name: boinc-client
+        state: stopped
+        enabled: false

--- a/provisioner/roles/manage_ec2_instances/templates/student_inventory/instances_rhel_90.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/student_inventory/instances_rhel_90.j2
@@ -1,1 +1,1 @@
-{% include 'instances_rhel.txt.j2' %}
+{% include 'instances_rhel.j2' %}

--- a/provisioner/roles/populate_tower/tasks/f5.yml
+++ b/provisioner/roles/populate_tower/tasks/f5.yml
@@ -1,0 +1,9 @@
+---
+- name: install demo
+  vars:
+    my_tower_username: admin
+    my_tower_password: "{{ admin_password }}"
+    my_tower_host: "{{ ansible_host }}"
+    demo: turn_off_community_grid
+  include_role:
+    name: "ansible.product_demos.install_demo"

--- a/provisioner/roles/populate_tower/tasks/rhel.yml
+++ b/provisioner/roles/populate_tower/tasks/rhel.yml
@@ -1,0 +1,9 @@
+---
+- name: install demo
+  vars:
+    my_tower_username: admin
+    my_tower_password: "{{ admin_password }}"
+    my_tower_host: "{{ ansible_host }}"
+    demo: turn_off_community_grid
+  include_role:
+    name: "ansible.product_demos.install_demo"

--- a/provisioner/roles/populate_tower/tasks/rhel_90.yml
+++ b/provisioner/roles/populate_tower/tasks/rhel_90.yml
@@ -18,3 +18,12 @@
     demo: hardening
   include_role:
     name: "ansible.product_demos.install_demo"
+
+- name: install demo
+  vars:
+    my_tower_username: admin
+    my_tower_password: "{{ admin_password }}"
+    my_tower_host: "{{ ansible_host }}"
+    demo: turn_off_community_grid
+  include_role:
+    name: "ansible.product_demos.install_demo"


### PR DESCRIPTION
##### SUMMARY

This feature will add Ansible Platform Job Templates to the `rhel`, `rhel_90` and `f5` workshop types where IBM Community Grid defaults to ton.  This allows any student or instructor to disable boinc-client from both the command-line and Ansible UI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
I did some time testing here... the CI testing did not capture timing of certain exercise.  It seemed like the 1.7 roles exercise time increased by 1 minute versus 8 seconds, that has some concern to me.  I am going to also try reducing CPU load.
