### PR TITLE
Epel $releasever fix

### DIFF
--- a/exercises/ansible_f5/turn_off_community_grid.yml
+++ b/exercises/ansible_f5/turn_off_community_grid.yml
@@ -2,7 +2,7 @@
 - name: turn off community-grid
   hosts: web
   gather_facts: false
-  become: yes
+  become: true
   tasks:
     - name: enable and start boinc-client
       systemd:

--- a/exercises/ansible_rhel/turn_off_community_grid.yml
+++ b/exercises/ansible_rhel/turn_off_community_grid.yml
@@ -2,7 +2,7 @@
 - name: turn off community-grid
   hosts: web
   gather_facts: false
-  become: yes
+  become: true
   tasks:
     - name: enable and start boinc-client
       systemd:

--- a/exercises/ansible_rhel_90/turn_off_community_grid.yml
+++ b/exercises/ansible_rhel_90/turn_off_community_grid.yml
@@ -2,7 +2,7 @@
 - name: turn off community-grid
   hosts: web
   gather_facts: false
-  become: yes
+  become: true
   tasks:
     - name: enable and start boinc-client
       systemd:

--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -15,6 +15,8 @@
       loop:
         - /etc/yum.repos.d/epel-modular.repo
         - /etc/yum.repos.d/epel.repo
+      when:
+        - ansible_distribution_major_version|int == 8
 
     - name: install boinc-client with package module
       package:

--- a/provisioner/roles/community_grid/tasks/main.yml
+++ b/provisioner/roles/community_grid/tasks/main.yml
@@ -6,6 +6,16 @@
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
         state: present
 
+    # temporary fix for rhel 8.2 dnf substitution
+    - name: fix EPEL repo substitution
+      replace:
+        path: "{{ item }}"
+        regexp: '\$releasever'
+        replace: '8'
+      loop:
+        - /etc/yum.repos.d/epel-modular.repo
+        - /etc/yum.repos.d/epel.repo
+
     - name: install boinc-client with package module
       package:
         name:

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -16,6 +16,8 @@
   loop:
     - /etc/yum.repos.d/epel-modular.repo
     - /etc/yum.repos.d/epel.repo
+  when:
+    - ansible_distribution_major_version|int == 8
 
 - name: Install base packages
   dnf:

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -10,9 +10,12 @@
 # temporary fix for rhel 8.2 dnf substitution
 - name: fix EPEL repo substitution
   replace:
-    path: /etc/yum.repos.d/epel-modular.repo
+    path: "{{ item }}"
     regexp: '\$releasever'
     replace: '8'
+  loop:
+    - /etc/yum.repos.d/epel-modular.repo
+    - /etc/yum.repos.d/epel.repo
 
 - name: Install base packages
   dnf:

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -7,6 +7,13 @@
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
 
+# temporary fix for rhel 8.2 dnf substitution
+- name: fix EPEL repo substitution
+  replace:
+    path: /etc/yum.repos.d/epel-modular.repo
+    regexp: '\$releasever'
+    replace: '8'
+
 - name: Install base packages
   dnf:
     name:

--- a/provisioner/roles/gitlab-server/tasks/certbot.yml
+++ b/provisioner/roles/gitlab-server/tasks/certbot.yml
@@ -19,6 +19,16 @@
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
         state: present
 
+    # temporary fix for rhel 8.2 dnf substitution
+    - name: fix EPEL repo substitution
+      replace:
+        path: "{{ item }}"
+        regexp: '\$releasever'
+        replace: '8'
+      loop:
+        - /etc/yum.repos.d/epel-modular.repo
+        - /etc/yum.repos.d/epel.repo
+
     - name: GitLab post | IInstall base packages
       dnf:
         name:

--- a/provisioner/roles/gitlab-server/tasks/certbot.yml
+++ b/provisioner/roles/gitlab-server/tasks/certbot.yml
@@ -28,6 +28,8 @@
       loop:
         - /etc/yum.repos.d/epel-modular.repo
         - /etc/yum.repos.d/epel.repo
+      when:
+        - ansible_distribution_major_version|int == 8
 
     - name: GitLab post | IInstall base packages
       dnf:


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a dnf substitution issue for `$releasever` in epel repo files
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Error was
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [control_node : Install EPEL] ************************************************************************************************************************
fatal: [wave-2-student1-ansible]: FAILED! => changed=false
  msg: 'Failed to download metadata for repo ''epel-modular'': Cannot prepare internal mirrorlist: Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=epel-modular-8.2&arch=x86_64&infra=$infra&content=$contentdir (IP: 140.211.169.196)'
  rc: 1
  results: []
```
