### PR TITLE
Removed async from 2 yum tasks in security.yml to fix issue when stud…

### DIFF
--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -16,30 +16,15 @@
 - name: Install Pre Reqs on attacker
   hosts: attack
   become: true
-  vars:
-    async_timeout_seconds: "{{ student_total * 60 }}"
-    async_wait_for_retries: "{{ student_total * 10}}"
   tasks:
     - name: setup epel on attacker
       include_role:
         name: "geerlingguy.repo-epel"
 
-    - name: package pre-reqs are installed async
+    - name: package pre-reqs are installed
       yum:
         state: present
-        name:
-          - daemonize
-      async: "{{ async_timeout_seconds }}"
-      poll: 0
-      register: yum_async
-
-    - name: wait for pre-reqs install async
-      async_status:
-        jid: "{{ yum_async.ansible_job_id }}"
-      register: job_result
-      until: job_result.finished
-      retries: "{{ async_wait_for_retries }}"
-
+        name: daemonize
 
 - name: include splunk playbook
   import_playbook: splunk.yml
@@ -59,8 +44,6 @@
     ids_install_snort_group: root
     ids_normalize_logs: false
     ids_install_snort_interface: eth1
-    async_timeout_seconds: "{{ student_total * 60 }}"
-    async_wait_for_retries: "{{ student_total * 10 }}"
   tasks:
     - name: Set fact vars for ids based SIEM type
       block:
@@ -86,16 +69,6 @@
             name:
               - libselinux-python
               - python2-idstools
-          async: "{{ async_timeout_seconds }}"
-          poll: 0
-          register: yum_async
-
-        - name: wait for pre-reqs install async
-          async_status:
-            jid: "{{ yum_async.ansible_job_id }}"
-          register: job_result
-          until: job_result.finished
-          retries: "{{ async_wait_for_retries }}"
 
         - name: set selinux permissve because of policy issue that breaks snort
           selinux:


### PR DESCRIPTION
…ent count 1

##### SUMMARY
An async task was failing in security.yml as the retries where a multiple of student_number and when set to 1 this could cause failures.

Removed async code from 2 yum tasks because in the first case there was no clear advantage as no other work was being executed prior to waiting for completion.

In the 2nd case yum was iterating over a list of 2 packages and AFAIK yum module us not async safe in this use case and there was little(nothing?) lost by simplifying the code here.


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME

- provisioner


##### ADDITIONAL INFORMATION
Only impacts Security Workshop