### PR TITLE
update code-server 2 to 3

### DIFF
--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -25,37 +25,39 @@
   delegate_to: localhost
   register: route53_status
 
-- name: Extract file
-  unarchive:
-    src: '{{ codeserver_url | default("https://github.com/cdr/code-server/releases/download/2.1698/code-server2.1698-vsc1.41.1-linux-x86_64.tar.gz") }}'
-    dest: "/home/{{ username }}"
-    remote_src: true
-    list_files: true
-  register: unarchive_out
+- name: Download code-server 3 rpm
+  get_url:
+    url: https://github.com/cdr/code-server/releases/download/v3.4.1/code-server-3.4.1-amd64.rpm
+    dest: /tmp/code-server.rpm
+    mode: '0440'
 
-# this usage of unarchive_out will get us into trouble if archive contains more then one top level directory. But it doesn't ;)
-- name: move binary to /opt
-  copy:
-    src: /home/{{username}}/{{ unarchive_out.files[0] }}/code-server
-    dest: /opt/code-server
-    remote_src: true
-    mode: '0744'
-    owner: "{{username}}"
-    group: "{{username}}"
+- name: install code-server 3 rpm from local rpm
+  dnf:
+    name: /tmp/code-server.rpm
+    state: present
 
-- name: update nginx configuration to support code server
-  blockinfile:
-    block: "{{ lookup('template', 'nginx.conf') }}"
-    dest: /etc/nginx/nginx.conf
-    insertafter: "http {"
+# - name: copy code-server unit file to global instead of user dir
+#   copy:
+#     src: /usr/lib/systemd/user/code-server.service
+#     dest: /etc/systemd/system
+#     owner: "{{username}}"
+#     group: wheel
+#     mode: '0744'
+#     remote_src: yes
 
-- name: Apply systemd service file
+- name: Apply our systemd service file (instead of RPM file)
   template:
     src: code-server.service.j2
     dest: /etc/systemd/system/code-server.service
     owner: "{{username}}"
     group: wheel
     mode: '0744'
+
+- name: update nginx configuration to support code server
+  blockinfile:
+    block: "{{ lookup('template', 'nginx.conf') }}"
+    dest: /etc/nginx/nginx.conf
+    insertafter: "http {"
 
 # source: https://vscode.readthedocs.io/en/latest/getstarted/settings/
 - name: ensure custom facts directory exists
@@ -84,7 +86,7 @@
 
 - name: install ansible and markdown extensions
   become_user: "{{ username }}"
-  command: "/opt/code-server --install-extension /home/{{ username }}/.local/share/code-server/extensions/{{ item }}"
+  command: "/bin/code-server --install-extension /home/{{ username }}/.local/share/code-server/extensions/{{ item }}"
   loop:
     - bierner.markdown-preview-github-styles-0.1.6.vsix
     - hnw.vscode-auto-open-markdown-preview-0.0.4.vsix
@@ -94,11 +96,12 @@
   until: install_extension is not failed
   retries: 5
 
-- name: start code-server service
-  service:
-    name: code-server
+- name: daemon-reload, enable and start code-server
+  systemd:
+    enabled: yes
     state: started
-    enabled: true
+    daemon_reload: yes
+    name: code-server
 
 - name: issue cert
   shell: /usr/local/bin/certbot-auto certonly --no-bootstrap --standalone -d {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
@@ -112,8 +115,3 @@
   register: install_tower
   until: install_tower is not failed
   retries: 5
-
-- name: cleanup Coder binary from student directory
-  file:
-    path: /home/{{username}}/{{ unarchive_out.files[0] }}
-    state: absent

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -89,9 +89,9 @@
 
 - name: daemon-reload, enable and start code-server
   systemd:
-    enabled: yes
+    enabled: true
     state: started
-    daemon_reload: yes
+    daemon_reload: true
     name: code-server
 
 - name: issue cert

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -36,15 +36,6 @@
     name: /tmp/code-server.rpm
     state: present
 
-# - name: copy code-server unit file to global instead of user dir
-#   copy:
-#     src: /usr/lib/systemd/user/code-server.service
-#     dest: /etc/systemd/system
-#     owner: "{{username}}"
-#     group: wheel
-#     mode: '0744'
-#     remote_src: yes
-
 - name: Apply our systemd service file (instead of RPM file)
   template:
     src: code-server.service.j2

--- a/provisioner/roles/code_server/templates/code-server.service.j2
+++ b/provisioner/roles/code_server/templates/code-server.service.j2
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=10
 Environment="PASSWORD={{admin_password}}"
 
-ExecStart=/opt/code-server /home/{{username}} --cert
+ExecStart=/bin/code-server
 ExecStop=/bin/kill -s QUIT $MAINPID
 
 

--- a/provisioner/roles/code_server/templates/nginx.conf
+++ b/provisioner/roles/code_server/templates/nginx.conf
@@ -6,7 +6,7 @@
         listen [::]:443;
         server_name {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}};
       location / {
-          proxy_pass https://127.0.0.1:8080;
+          proxy_pass http://127.0.0.1:8080;
           proxy_set_header Host $host;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection upgrade;


### PR DESCRIPTION
##### SUMMARY
Update from code-server 2 to 3. Code-server is now packaged as RPM, makes life slightly easier.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
- I'm using the custom systemd unit file like before and not the one now part of the RPM package to make running code-server as student user easier.
- Password is set in unit file ENV (like before), the login screen says now "Password was set from $PASSWORD.". Looks a bit weird, but works fine. Otherwise I'd have to stop code-server, change `.config/code-server/config.yaml` and start again. Up for discussion.
- I left the installation of extensions and config like before, looks okay so far. 