### PR TITLE
Ensure connection used for localhost is local

### DIFF
--- a/provisioner/hosts
+++ b/provisioner/hosts
@@ -1,1 +1,1 @@
-localhost   ansible_python_interpreter="/usr/bin/env python"
+localhost   ansible_python_interpreter="/usr/bin/env python" ansible_connection=local


### PR DESCRIPTION
Fixing CI failures:

```
[2020-06-17T00:50:22.074Z] TASK [workshop_attendance : GitLab post | Create DNS record] *******************
[2020-06-17T00:50:22.074Z] fatal: [attendance-host]: UNREACHABLE! => changed=false 
[2020-06-17T00:50:22.074Z]   msg: 'Failed to connect to the host via ssh: ssh: connect to host localhost port 22: Connection refused'
[2020-06-17T00:50:22.074Z]   unreachable: true
```

I suspect this change is responsible for this change of behavior https://github.com/ansible/ansible/commit/9e00214fb435e6b9ea223d966c2e4d9feecac35f