### PR TITLE
update roles with conditionals to use include_role

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -32,13 +32,13 @@
   hosts: attendance
   become: true
   gather_facts: true
-  roles:
-    - role: workshop_attendance_nginx
-      when:
-        - attendance|bool
-    - role: workshop_attendance
-      when:
-        - attendance|bool
+  tasks:
+    - block:
+        - include_role:
+            name: workshop_attendance_nginx
+        - include_role:
+            name: workshop_attendance
+      when: attendance|bool
 
 - name: wait for all security nodes to have SSH reachability
   hosts: "security_connection_check"
@@ -61,7 +61,9 @@
   become: true
   roles:
     - role: control_node
-    - role: code_server
+  tasks:
+    - include_role:
+        name: code_server
       when:
         - code_server is defined
         - code_server
@@ -72,8 +74,9 @@
   hosts: control_nodes
   become: true
   gather_facts: false
-  roles:
-    - role: aws_dns
+  tasks:
+    - include_role:
+        name: aws_dns
       when:
         - dns_type is defined
         - dns_type == "aws"
@@ -86,8 +89,9 @@
   connection: local
   become: false
   gather_facts: false
-  roles:
-    - role: aws_workshop_login_page
+  tasks:
+    - include_role:
+        name: aws_workshop_login_page
       when:
         - create_login_page is defined
         - create_login_page


### PR DESCRIPTION
##### SUMMARY
The current plays in provision_lab.yml with conditionals on roles will not work as intended.  Need to set them as include_role to act on conditionals.

Example:
  tasks:
    - block:
        - include_role:
            name: workshop_attendance_nginx
        - include_role:
            name: workshop_attendance
      when: attendance|bool
vs.
  roles:
    - role: workshop_attendance_nginx
      when:
        - attendance|bool
    - role: workshop_attendance
      when:
        - attendance|bool

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
Below task now skips the workshop_attendance* roles when attendance: false
```
- name: Configure nginx on attendance host
  hosts: attendance
  become: true
  gather_facts: true
  tasks:
    - block:
        - include_role:
            name: workshop_attendance_nginx
        - include_role:
            name: workshop_attendance
      when: attendance|bool
```
