### PR TITLE
Install idstool via pip since package is missing from EPEL

### DIFF
--- a/provisioner/security.yml
+++ b/provisioner/security.yml
@@ -68,7 +68,13 @@
             state: present
             name:
               - libselinux-python
-              - python2-idstools
+              - python-virtualenv
+              - python-setuptools
+              - python-pip
+
+        - name: install idstools
+          pip:
+            name: idstools
 
         - name: set selinux permissve because of policy issue that breaks snort
           selinux:


### PR DESCRIPTION
##### SUMMARY

Currently security workshop is broken because python2-idstool package is not in EPEL anymore.
This change installs idstool via pip.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

- provisioner

##### ADDITIONAL INFORMATION

See: https://bugzilla.redhat.com/show_bug.cgi?id=1856314