### PR TITLE
Remove undef become

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -155,7 +155,6 @@
 - name: print out information for instructor
   hosts: localhost
   connection: local
-  become:
   gather_facts: false
   tasks:
     - name: set facts for output


### PR DESCRIPTION
##### SUMMARY
Fix empty become which was causing all CI to fail with


```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: The value ‘None’ is not a valid boolean.  Valid booleans include: ‘n’, 1, ‘f’, 0, ‘y’, ‘yes’, ‘0’, ‘true’, ‘off’, ‘1’, ‘false’, ‘on’, ‘t’, ‘no’”

```



##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner
