### PR TITLE
Update README.ja.md

### DIFF
--- a/exercises/ansible_f5/2.1-delete-configuration/README.ja.md
+++ b/exercises/ansible_f5/2.1-delete-configuration/README.ja.md
@@ -176,7 +176,7 @@
       provider: "{{provider}}"
       name: "{{hostvars[item].inventory_hostname}}"
       state: absent
-    loop: "{{ groups['webservers'] }}"
+    loop: "{{ groups['web'] }}"
 ```
 {% endraw %}
 上記のPlaybookは、仮想サーバ、プール、前の実習で構成したノードの順に削除します。


### PR DESCRIPTION
references "webservers", but lab provisioner calls this group "web"

「webservers」を参照しますが、ラボプロビジョナーはこのグループを「web」と呼びます

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs
- decks
- provisioner
- demos

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
