### PR TITLE
removing backticks from file, breaking travisCI

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/httpd_conf.yml
+++ b/exercises/ansible_rhel/1.5-handlers/httpd_conf.yml
@@ -14,4 +14,3 @@
       service:
         name: httpd
         state: restarted
-```


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

ERROR: InvocationError for command /home/travis/build/redhat-cop/agnosticd/tests/static/.tox/py38-ansible_syntax/bin/python setup.py ansible_syntax (exited with code 1)

___________________________________ summary ____________________________________

ERROR:   py38-ansible_syntax: commands failed

The command "tox -c tests/static" exited with 1.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
