### PR TITLE
removing gpg flag

### DIFF
--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -6,6 +6,7 @@
   dnf:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
+    disable_gpg_check: true
 
 # temporary fix for rhel 8.2 dnf substitution
 - name: fix EPEL repo substitution


### PR DESCRIPTION
##### SUMMARY
getting rid of this error->
```
TASK [control_node : Install EPEL] *********************************************
fatal: [tqe-gating-xzhvtsvs-student2-ansible-1]: FAILED! => changed=false 
  msg: Failed to validate GPG signature for epel-release-8-8.el8.noarch
fatal: [tqe-gating-xzhvtsvs-student1-ansible-1]: FAILED! => changed=false 
  msg: Failed to validate GPG signature for epel-release-8-8.el8.noarch
```

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
n/a trying to get release out
