### PR TITLE
Update windows.yml

### DIFF
--- a/provisioner/windows.yml
+++ b/provisioner/windows.yml
@@ -14,7 +14,7 @@
         name: gitlab-server
 
 - name: Configure GitLab client
-  hosts: ansible-1
+  hosts: '*ansible-1'
   become: true
   gather_facts: true
   tags:


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Under "Configure GitLab client" "hosts" line missing leading "*" wildcard. During provisioning it was not creating the "workshop_project" directory needed for student's Gitlab repo and playbook exercises 3-7.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY [Configure GitLab client] ***********************************************************************************************************************
skipping: no hosts matched
```