### PR TITLE
Changes for Advanced Tower lab exercises

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -189,7 +189,9 @@
           - Instructor inventory is located at  {{playbook_dir}}/{{ec2_name_prefix}}/instructor_inventory.txt
           - Private key is located at {{playbook_dir}}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem
           - {{website_information}}
+          {% if attendance %}
           - {{hostvars['attendance-host'].login_website_information | default("attendance feature is off") }}
+          {% endif %}
 
           FAILURES
           *******************

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -50,7 +50,28 @@
     dest: /etc/nginx/nginx.conf
     insertafter: "http {"
 
-# source: https://vscode.readthedocs.io/en/latest/getstarted/settings/
+# Make sure we can re-run the Tower installer during a lab without killing code-server access
+- name: update Ansible installer nginx configuration template to support code server
+  blockinfile:
+    block: "{{ lookup('template', 'nginx.conf') }}"
+    dest: /tmp/tower_install/roles/nginx/templates/nginx.conf
+    insertafter: "http {"
+
+# Make the block inserted above conditional to only apply to ansible-1
+- name: Add jinja conditional start
+  lineinfile:
+    path: /tmp/tower_install/roles/nginx/templates/nginx.conf
+    insertafter: "http {"
+    line: '{% raw %} {% if ansible_hostname == "ansible-1" %} {% endraw %}'
+
+# Make the block inserted above conditional to only apply to ansible-1
+- name: Add jinja conditional end
+  lineinfile:
+    path: /tmp/tower_install/roles/nginx/templates/nginx.conf
+    insertbefore: "include(.*)/etc/nginx/mime.types;"
+    line: '{% raw %} {% endif %} {% endraw %}'
+
+    # source: https://vscode.readthedocs.io/en/latest/getstarted/settings/
 - name: ensure custom facts directory exists
   file:
     path: "/home/{{username}}/.local/share/code-server/User/"

--- a/provisioner/roles/control_node/templates/tower_cluster_install.j2
+++ b/provisioner/roles/control_node/templates/tower_cluster_install.j2
@@ -13,23 +13,13 @@ ansible_ssh_private_key_file=/home/ec2-user/.ssh/aws-private.pem
 ansible_become=yes
 ansible_ssh_common_args='-o StrictHostKeyChecking=no'
 
-
-
 pg_host='ansible-4'
 pg_port='5432'
 
 pg_database='awx'
 pg_username='awx'
 pg_password='{{admin_password}}'
-
-rabbitmq_port=5672
-rabbitmq_vhost=tower
-rabbitmq_username=tower
-rabbitmq_password='{{admin_password}}'
-rabbitmq_cookie=cookiemonster
-
-# Needs to be true for fqdns and ip addresses
-rabbitmq_use_long_name=false
+pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
 
 gpgcheck='{{ gpgcheck | default(1)}}'
 aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'

--- a/provisioner/roles/control_node/templates/tower_install.j2
+++ b/provisioner/roles/control_node/templates/tower_install.j2
@@ -12,15 +12,7 @@ pg_port=''
 pg_database='awx'
 pg_username='awx'
 pg_password='{{admin_password}}'
-
-rabbitmq_port=5672
-rabbitmq_vhost=tower
-rabbitmq_username=tower
-rabbitmq_password='{{admin_password}}'
-rabbitmq_cookie=cookiemonster
-
-# Needs to be true for fqdns and ip addresses
-rabbitmq_use_long_name=false
+pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
 
 gpgcheck='{{ gpgcheck | default(1)}}'
 aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'

--- a/provisioner/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
@@ -130,3 +130,95 @@
   with_indexed_items:
     - "{{ node3_output.instances }}"
   when: node3_output.instance_ids is not none
+
+# Create isolated/remote node for Adv Tower lab when cluster install
+
+- name: Create EC2 instances for isonode
+  ec2:
+    assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    group: "{{ ec2_security_group }}"
+    instance_type: "{{ ec2_info[rhel].size }}"
+    image: "{{ node_ami.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total }}"
+    count_tag:
+      Workshop_isonode: "{{ ec2_name_prefix }}-isonode"
+    instance_tags:
+      Workshop_isonode: "{{ ec2_name_prefix }}-isonode"
+      Workshop: "{{ ec2_name_prefix }}"
+      Workshop_type: "{{ workshop_type }}"
+      AWS_USERNAME: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{ student_total }}"
+      short_name: "isonode"
+      username: "{{ ec2_info[rhel].username }}"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    volumes:
+      - device_name: /dev/sda1
+        volume_type: gp2
+        volume_size: "{{ ec2_info[rhel].disk_space }}"
+        delete_on_termination: true
+  register: isonode_output
+  when: create_cluster|bool
+
+- name: Ensure tags are present for isonode
+  ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{ item.1.id }}"
+    state: present
+    tags:
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-isonode"
+      Index: "{{ item[0] }}"
+      Student: "student{{ item.0 + 1 }}"
+      launch_time: "{{ item.1.launch_time }}"
+  with_indexed_items:
+    - "{{ isonode_output.instances }}"
+  when: isonode_output.instance_ids is not none
+
+- name: Create EC2 instances for remotenode
+  ec2:
+    assign_public_ip: true
+    key_name: "{{ ec2_name_prefix }}-key"
+    group: "{{ ec2_security_group }}"
+    instance_type: "{{ ec2_info[rhel].size }}"
+    image: "{{ node_ami.image_id }}"
+    region: "{{ ec2_region }}"
+    exact_count: "{{ student_total }}"
+    count_tag:
+      Workshop_remotenode: "{{ ec2_name_prefix }}-remotenode"
+    instance_tags:
+      Workshop_remotenode: "{{ ec2_name_prefix }}-remotenode"
+      Workshop: "{{ ec2_name_prefix }}"
+      Workshop_type: "{{ workshop_type }}"
+      AWS_USERNAME: "{{ aws_user }}"
+      Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
+      Linklight: "This was provisioned through the linklight provisioner"
+      Students: "{{ student_total }}"
+      short_name: "remotenode"
+      username: "{{ ec2_info[rhel].username }}"
+    wait: "{{ ec2_wait }}"
+    vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
+    volumes:
+      - device_name: /dev/sda1
+        volume_type: gp2
+        volume_size: "{{ ec2_info[rhel].disk_space }}"
+        delete_on_termination: true
+  register: remotenode_output
+  when: create_cluster|bool
+
+- name: Ensure tags are present for remotenode
+  ec2_tag:
+    region: "{{ ec2_region }}"
+    resource: "{{ item.1.id }}"
+    state: present
+    tags:
+      Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-remotenode"
+      Index: "{{ item[0] }}"
+      Student: "student{{ item.0 + 1 }}"
+      launch_time: "{{ item.1.launch_time }}"
+  with_indexed_items:
+    - "{{ remotenode_output.instances }}"
+  when: remotenode_output.instance_ids is not none

--- a/provisioner/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
@@ -176,7 +176,7 @@
       launch_time: "{{ item.1.launch_time }}"
   with_indexed_items:
     - "{{ isonode_output.instances }}"
-  when: isonode_output.instance_ids is not none
+  when: isonode_output.instance_ids is not none and create_cluster|bool
 
 - name: Create EC2 instances for remotenode
   ec2:
@@ -221,4 +221,4 @@
       launch_time: "{{ item.1.launch_time }}"
   with_indexed_items:
     - "{{ remotenode_output.instances }}"
-  when: remotenode_output.instance_ids is not none
+  when: remotenode_output.instance_ids is not none and create_cluster|bool

--- a/provisioner/roles/manage_ec2_instances/tasks/inventory/addhost_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/inventory/addhost_rhel.yml
@@ -70,5 +70,5 @@
   with_items:
     - "{{ isonode_node_facts.instances }}"
     - "{{ remotenode_node_facts.instances }}"
-  #changed_when: false
+  # changed_when: false
   when: create_cluster|bool

--- a/provisioner/roles/manage_ec2_instances/tasks/inventory/addhost_rhel.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/inventory/addhost_rhel.yml
@@ -23,6 +23,24 @@
       "tag:Workshop_node3": "{{ec2_name_prefix}}-node3"
   register: node3_node_facts
 
+- name: grab facts for isonode
+  ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_isonode": "{{ec2_name_prefix}}-isonode"
+  register: isonode_node_facts
+  when: create_cluster|bool
+
+- name: grab facts for remotenode node
+  ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_remotenode": "{{ec2_name_prefix}}-remotenode"
+  register: remotenode_node_facts
+  when: create_cluster|bool
+
 - name: add hosts to groups (ANSIBLE RHEL MODE)
   add_host:
     name: "{{ item.tags.Name }}"
@@ -38,3 +56,19 @@
     - "{{ node2_node_facts.instances }}"
     - "{{ node3_node_facts.instances }}"
   changed_when: false
+
+- name: add nodes for cluster lab to groups (ANSIBLE RHEL MODE)
+  add_host:
+    name: "{{ item.tags.Name }}"
+    username: "{{ item.tags.Student }}"
+    short_name: "{{ item.tags.short_name }}"
+    ansible_host: "{{ item.public_ip_address }}"
+    ansible_user: "{{ item.tags.username }}"
+    ansible_port: "{{ ssh_port }}"
+    ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ec2_name_prefix}}-private.pem"
+    groups: lab_hosts,managed_nodes
+  with_items:
+    - "{{ isonode_node_facts.instances }}"
+    - "{{ remotenode_node_facts.instances }}"
+  #changed_when: false
+  when: create_cluster|bool

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
@@ -3,21 +3,37 @@
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{ vm.tags.short_name }}
+{{ vm.private_ip_address }} {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}
 {% endif %}
 {% endfor %}
 
 {% for vm in node3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.public_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}
 {% endif %}
 {% endfor %}
+
+{% if create_cluster %}
+{% for vm in isonode_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if create_cluster %}
+{% for vm in remotenode_node_facts.instances %}
+{% if 'student' + item == vm.tags.Student %}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{% endif %}
+{% endfor %}
+{% endif %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}


### PR DESCRIPTION
##### SUMMARY
This proposes a couple of changes to make the Summit Advanced Tower lab exercises (part of the AnsibleFest labs, too) run on the cluster RHEL lab environment. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
- The Tower installer is run as part of the lab to deploy an isolated node. Changing the nginx.conf template to not blow away the code-server block.
- Adding two nodes for isolated node exercise
- Minor: Changing the IPs in /etc/hosts template to private IPs
- Minor: make final output conditional for attendance feature (otherwise fails when attendance is switched off)
- Minor: taking the rabbitmq lines out of the Tower installer inventory (I understand it's not needed anymore?)

@liquidat @IPvSean @termlen0 @cloin 
