### PR TITLE
Update README.md for f5 workshop ex 1.4 display-pool-members.yml

### DIFF
--- a/exercises/ansible_f5/1.4-add-pool-members/README.md
+++ b/exercises/ansible_f5/1.4-add-pool-members/README.md
@@ -138,11 +138,12 @@ Enter the following:
 
   - name: Query BIG-IP facts
     bigip_device_info:
-      server: "{{private_ip}}"
-      user: "{{ansible_user}}"
-      password: "{{ansible_ssh_pass}}"
-      server_port: "8443"
-      validate_certs: "no"
+      provider:
+        server: "{{private_ip}}"
+        user: "{{ansible_user}}"
+        password: "{{ansible_ssh_pass}}"
+        server_port: "8443"
+        validate_certs: "no"
       gather_subset:
        - ltm-pools
     register: bigip_device_facts


### PR DESCRIPTION
Missing provider: in the output parse playbook display-pool-members.yml

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs
- decks
- provisioner
- demos

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
