### PR TITLE
Fix issues with Attendance page with the Devops Workshop

### DIFF
--- a/provisioner/roles/workshop_attendance/templates/index.php.j2
+++ b/provisioner/roles/workshop_attendance/templates/index.php.j2
@@ -562,7 +562,7 @@ function display_student($student) {
   {% endif %}
   </div>
 
-  {% if workshop_type in ['devops'] %} Lab Guide: <a target=_blank href="http://student' . $student['password'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888">http://student' . $student['password'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888</a><br>{% endif %}
+  {% if workshop_type in ['devops'] %} Lab Guide: <a target=_blank href="http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888">http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888</a><br>{% endif %}
       </div>
     </div>';
 


### PR DESCRIPTION
##### SUMMARY
When using the Attendance Page with the Devops workshop, the index page is displaying an incorrect url.  Looks like a copy and paste error, should be using the id field, not the password field.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
