### PR TITLE
Fix Windows Inventory Name

### DIFF
--- a/exercises/ansible_windows/1-tower/README.fr.md
+++ b/exercises/ansible_windows/1-tower/README.fr.md
@@ -161,7 +161,7 @@ Un inventaire statique a déjà été créé pour vous aujourd'hui. Nous allons 
 Étape 1:
 --------
 
-Cliquez sur **Inventaires** dans le panneau de gauche. Vous verrez l'inventaire préconfiguré répertorié. Cliquez sur le nom de inventaire **Windows Workshop Inventory** ou sur le bouton Modifier.
+Cliquez sur **Inventaires** dans le panneau de gauche. Vous verrez l'inventaire préconfiguré répertorié. Cliquez sur le nom de inventaire **Workshop Inventory** ou sur le bouton Modifier.
 
 ![Edit](images/at_edit.png)
 

--- a/exercises/ansible_windows/1-tower/README.ja.md
+++ b/exercises/ansible_windows/1-tower/README.ja.md
@@ -126,7 +126,7 @@ SCM 更新オプション
 ### ステップ 1:  
 
 左側のパネルで **インベントリー** をクリックします。事前に作成されたインベントリー情報が見えます。    
-**Windows Workshop Inventory** という名前のインベントリーもしくは編集アイコン ![Edit](images/at_edit.png)　をクリックします。    
+**Workshop Inventory** という名前のインベントリーもしくは編集アイコン ![Edit](images/at_edit.png)　をクリックします。    
 
 ### ステップ 2:  
 

--- a/exercises/ansible_windows/1-tower/README.md
+++ b/exercises/ansible_windows/1-tower/README.md
@@ -177,8 +177,7 @@ Step 1:
 -------
 
 Click **Inventories** from the left hand panel. You will see the
-preconfigured Inventory listed. Click the Inventories' name **Windows
-Workshop Inventory** or the Edit button. ![Edit](images/at_edit.png)
+preconfigured Inventory listed. Click the Inventories' name **Workshop Inventory** or the Edit button. ![Edit](images/at_edit.png)
 
 Step 2:
 -------

--- a/exercises/ansible_windows/4-projects/README.fr.md
+++ b/exercises/ansible_windows/4-projects/README.fr.md
@@ -34,7 +34,7 @@ Remplissez le formulaire en utilisant les valeurs suivantes
 | Name        | IIS Basic Job Template                       |      |
 | Description | Template for the iis-basic playbook          |      |
 | JOB TYPE    | Run                                          |      |
-| INVENTORY   | Windows Workshop Inventory                   |      |
+| INVENTORY   | Workshop Inventory                   |      |
 | PROJECT     | Ansible Workshop Project                     |      |
 | PLAYBOOK    | `iis-basic/install_iis.yml`                  |      |
 | CREDENTIAL  | Type: **Machine**. Name: **Student Account** |      |

--- a/exercises/ansible_windows/4-projects/README.ja.md
+++ b/exercises/ansible_windows/4-projects/README.ja.md
@@ -45,7 +45,7 @@ Playbook 実行に必要な以下のオブジェクトを紐づけて定義し�
 | 名前        | IIS Basic Job Template                       |      |
 | 説明 | Template for the iis-basic playbook          |      |
 | ジョブタイプ    | 実行                                          |      |
-| インベントリー   | Windows Workshop Inventory                   |      |
+| インベントリー   | Workshop Inventory                   |      |
 | プロジェクト     | Ansible Workshop Project                     |      |
 | PLAYBOOK    | `iis-basic/install_iis.yml`                  |      |
 | 認証情報  | 認証情報タイプ: **マシン**. 名前: **Student Account** |      |

--- a/exercises/ansible_windows/5-adv-playbook/README.fr.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.fr.md
@@ -338,7 +338,7 @@ Remplissez le formulaire en utilisant les valeurs suivantes
 | Nom         | IIS Advanced               |      |
 | Description | Template for iis_advanced  |      |
 | JOB TYPE    | Run                        |      |
-| INVENTORY   | Windows Workshop Inventory |      |
+| INVENTORY   | Workshop Inventory |      |
 | PROJECT     | Ansible Workshop Project   |      |
 | PLAYBOOK    | `iis_advanced/site.yml`    |      |
 | CREDENTIAL  | Student Account            |      |

--- a/exercises/ansible_windows/5-adv-playbook/README.ja.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.ja.md
@@ -312,7 +312,7 @@ Playbook は以下のようになっているはずです。もう一度確認�
 | 名前        | IIS Advanced               |      |
 | 説明 | Template for iis_advanced  |      |
 | ジョブタイプ    | 実行                        |      |
-| インベントリー   | Windows Workshop Inventory |      |
+| インベントリー   | Workshop Inventory |      |
 | プロジェクト     | Ansible Workshop Project   |      |
 | PLAYBOOK    | `iis_advanced/site.yml`    |      |
 | 認証情報  | Student Account            |      |

--- a/exercises/ansible_windows/5-adv-playbook/README.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.md
@@ -402,7 +402,7 @@ Complete the form using the following values
 | Name        | IIS Advanced               |      |
 | Description | Template for iis_advanced  |      |
 | JOB TYPE    | Run                        |      |
-| INVENTORY   | Windows Workshop Inventory |      |
+| INVENTORY   | Workshop Inventory |      |
 | PROJECT     | Ansible Workshop Project   |      |
 | PLAYBOOK    | `iis_advanced/site.yml`    |      |
 | CREDENTIAL  | Student Account            |      |

--- a/exercises/ansible_windows/7-win-patch/README.fr.md
+++ b/exercises/ansible_windows/7-win-patch/README.fr.md
@@ -86,7 +86,7 @@ Remplissez le formulaire en utilisant les valeurs suivantes
 | NOM                | Windows Updates            |      |
 | DESCRIPTION        |                            |      |
 | JOB TYPE           | Run                        |      |
-| INVENTAIRE         | Windows Workshop Inventory |      |
+| INVENTAIRE         | Workshop Inventory |      |
 | PROJET             | Ansible Workshop Project   |      |
 | Playbook           | `win_updates/site.yml`     |      |
 | MACHINE CREDENTIAL | Student Account            |      |

--- a/exercises/ansible_windows/7-win-patch/README.ja.md
+++ b/exercises/ansible_windows/7-win-patch/README.ja.md
@@ -82,7 +82,7 @@ Ansible Tower の GUI に戻ってプロジェクトの同期を行います。�
 | 名前               | Windows Updates            |      |
 | 説明        |                            |      |
 | ジョブタイプ           | 実行                        |      |
-| インベントリー          | Windows Workshop Inventory |      |
+| インベントリー          | Workshop Inventory |      |
 | プロジェクト            | Ansible Workshop Project   |      |
 | PLAYBOOK           | `win_updates/site.yml`     |      |
 | 認証情報 | Student Account            |      |

--- a/exercises/ansible_windows/7-win-patch/README.md
+++ b/exercises/ansible_windows/7-win-patch/README.md
@@ -115,7 +115,7 @@ Complete the form using the following values
 | NAME               | Windows Updates            |      |
 | DESCRIPTION        |                            |      |
 | JOB TYPE           | Run                        |      |
-| INVENTORY          | Windows Workshop Inventory |      |
+| INVENTORY          | Workshop Inventory |      |
 | PROJECT            | Ansible Workshop Project   |      |
 | Playbook           | `win_updates/site.yml`     |      |
 | MACHINE CREDENTIAL | Student Account            |      |


### PR DESCRIPTION
##### SUMMARY
A recent commit fixed the Windows Inventory name in Exercise 4 - English, but didn't fix it in all the other exercises and languages.  This commit does that.

Just to note, this only fixes the text.  There are multiple images that also need to be redone to remove it from them.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises
