### PR TITLE
Windows: Ensure only winrm connection images get templated

### DIFF
--- a/provisioner/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_windows.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/instructor_inventory/instructor_inventory_windows.j2
@@ -12,7 +12,7 @@ ansible_winrm_server_cert_validation=ignore
 ansible_port=5986
 
 {%   for host in hostvars %}
-{%     if "win" in host %}
+{%     if hostvars[host].get('ansible_connection', '') == 'winrm' %}
 [windows]
 {{ host|replace(ec2_name_prefix + "-", "") }} ansible_host={{ hostvars[host].ansible_host }} ansible_password="{{ hostvars[host].ansible_password }}"
 {%     endif %}


### PR DESCRIPTION
The current filter to restrict the template to windows machine is not
strict enough. `student1-test-win1` will gets templated, correctly, so does
`swingstate-election-date-is-coming`. The latter might not have an
ansible_password defined which leads to an undefined error.

```
msg: 'AnsibleUndefinedVariable: ''ansible.vars.hostvars.HostVarsVars
object'' has no attribute ''ansible_password'''
```

Regression introduced in: https://github.com/ansible/workshops/pull/993