### PR TITLE
Tower: Ignore prefligh check failures

### DIFF
--- a/provisioner/roles/control_node/templates/tower_cluster_install.j2
+++ b/provisioner/roles/control_node/templates/tower_cluster_install.j2
@@ -23,3 +23,4 @@ pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
 
 gpgcheck='{{ gpgcheck | default(1)}}'
 aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'
+ignore_preflight_errors = True

--- a/provisioner/roles/control_node/templates/tower_install.j2
+++ b/provisioner/roles/control_node/templates/tower_install.j2
@@ -16,3 +16,4 @@ pg_sslmode='prefer'  # set to 'verify-full' for client-side enforced SSL
 
 gpgcheck='{{ gpgcheck | default(1)}}'
 aw_repo_url='{{ aw_repo_url | default("https://releases.ansible.com/ansible-tower/") }}'
+ignore_preflight_errors = True


### PR DESCRIPTION
Something recently changed underneath us and `t2.medium` doesn't retrieve a "sufficient" amount of memory per Tower requirements. I suspect this is only by few Mb and hence think those checks can be discarded for the pruposes of the workshop (ie. we are not deploying production environments)