### PR TITLE
Place instructor inventory on filesystem

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -128,7 +128,7 @@ Please read this blog for more information: [https://www.ansible.com/blog/ansibl
 
 ## Accessing instructor inventory
 
-  - For workshops deploying Ansible Tower on the control_nodes, the instructor inventory will be copied to `/tmp` on student1's control_node. 
+  - The instructor inventory will be copied to `/tmp` on student1's control_node as part of the control_nodes role. 
 
 ## DNS
 

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -22,6 +22,7 @@ The `github.com/ansible/workshops` contains an Ansible Playbook `provision_lab.y
    * [Setup (per workshop)](#setup-per-workshop)
    * [IBM Community Grid](#ibm-community-grid)
    * [Accessing student documentation and slides](#accessing-student-documentation-and-slides)
+   * [Accessing instructor inventory](#accessing-instructor-inventory)
    * [DNS](#dns)
 * [Lab Teardown](#lab-teardown)
 * [Demos](#demos)
@@ -124,6 +125,10 @@ Please read this blog for more information: [https://www.ansible.com/blog/ansibl
        - **NOTE:** It is possible to change the DNS domain (right now this is only supported via a AWS Route 53 Hosted Zone) using the parameter `workshop_dns_zone` in your `extra_vars.yml` file.
 
        - **NOTE:** The playbook does not create the route53 zone and must exist prior to running the playbook.
+
+## Accessing instructor inventory
+
+  - For workshops deploying Ansible Tower on the control_nodes, the instructor inventory will be copied to `/tmp` on student1's control_node. 
 
 ## DNS
 

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -146,6 +146,14 @@
     group: "{{ username }}"
   when: username in inventory_hostname
 
+- name: Copy instructor inventory to student1
+  copy:
+    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/instructor_inventory.txt"
+    dest: /tmp/instructor-inventory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+  when: '"student1" in inventory_hostname'
+
 - name: setup control node for workshop type
   include_tasks: "{{item}}"
   with_first_found:


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This just copies the instructor inventory from the host provisioning the workshop to /tmp/ on student1’s control_node. Helpful for provisioning from RHPDS to give instructors access to a usable inventory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner