### PR TITLE
Fix removing login url when using attendance

### DIFF
--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -18,6 +18,7 @@
     - {include_role: {name: aws_dns}, when: create_login_page is defined and create_login_page}
     - {include_role: {name: code_server}, when: code_server}
     - {include_role: {name: gitlab-server}, when: workshop_type == "windows"}
+    - {include_role: {name: workshop_attendance}, when: attendance}
 
 
     - name: Remove workshop local files


### PR DESCRIPTION
#### SUMMARY
The login Route53 entry isn't being removed when using the attendance host.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
