### PR TITLE
Use manifest.zip with 3.8 file if found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bak/
 *.pem
 instructor_inventory.txt
 provisioner/tower_license.json
+provisioner/manifest.zip
 network_vars.yml
 ansible/
 *.box

--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -40,3 +40,6 @@ valid_security_console_types:
   - qradar
 ibm_community_grid: true
 create_cluster: false
+default_tower38_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.8.0-1.tar.gz
+default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.7.3-1.tar.gz
+use_manifest: false

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -79,6 +79,8 @@
   become: true
   vars:
     tower_license: "{{ hostvars['localhost']['tower_license'] }}"
+    use_manifest:  "{{ hostvars['localhost']['use_manifest'] }}"
+    default_tower_url:  "{{ hostvars['localhost']['default_tower_url'] }}"
   pre_tasks:
     - debug:
         var: tower_license

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -79,8 +79,8 @@
   become: true
   vars:
     tower_license: "{{ hostvars['localhost']['tower_license'] }}"
-    use_manifest:  "{{ hostvars['localhost']['use_manifest'] }}"
-    default_tower_url:  "{{ hostvars['localhost']['default_tower_url'] }}"
+    use_manifest: "{{ hostvars['localhost']['use_manifest'] }}"
+    default_tower_url: "{{ hostvars['localhost']['default_tower_url'] }}"
   pre_tasks:
     - debug:
         var: tower_license

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -117,20 +117,20 @@
   when: not use_manifest
 
 - block:
-  - name: Load manifest into variable
-    local_action:
-      module: slurp
-      src: "{{ playbook_dir }}/manifest.zip"
-    register: manifest_file
+    - name: Load manifest into variable
+      local_action:
+        module: slurp
+        src: "{{ playbook_dir }}/manifest.zip"
+      register: manifest_file
 
-  - name: Post manifest file
-    uri:
-      url: https://{{ansible_host}}/api/v2/config/
-      method: POST
-      user: admin
-      password: "{{admin_password}}"
-      body: '{ "eula_accepted": true, "manifest": "{{ manifest_file.content }}" }'
-      body_format: json
-      validate_certs: false
-      force_basic_auth: true
+    - name: Post manifest file
+      uri:
+        url: https://{{ansible_host}}/api/v2/config/
+        method: POST
+        user: admin
+        password: "{{admin_password}}"
+        body: '{ "eula_accepted": true, "manifest": "{{ manifest_file.content }}" }'
+        body_format: json
+        validate_certs: false
+        force_basic_auth: true
   when: use_manifest

--- a/provisioner/roles/control_node/tasks/tower.yml
+++ b/provisioner/roles/control_node/tasks/tower.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download Ansible Tower
   get_url:
-    url: '{{ tower_installer_url | default("https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.7.3-1.tar.gz") }}'
+    url: '{{ tower_installer_url | default(default_tower_url) }}'
     dest: /tmp/tower.tar.gz
 
 - name: Create directory for Ansible Tower
@@ -114,3 +114,23 @@
     body_format: json
     validate_certs: false
     force_basic_auth: true
+  when: not use_manifest
+
+- block:
+  - name: Load manifest into variable
+    local_action:
+      module: slurp
+      src: "{{ playbook_dir }}/manifest.zip"
+    register: manifest_file
+
+  - name: Post manifest file
+    uri:
+      url: https://{{ansible_host}}/api/v2/config/
+      method: POST
+      user: admin
+      password: "{{admin_password}}"
+      body: '{ "eula_accepted": true, "manifest": "{{ manifest_file.content }}" }'
+      body_format: json
+      validate_certs: false
+      force_basic_auth: true
+  when: use_manifest

--- a/provisioner/roles/workshop_check_setup/defaults/main.yml
+++ b/provisioner/roles/workshop_check_setup/defaults/main.yml
@@ -1,0 +1,1 @@
+use_manifest: false

--- a/provisioner/roles/workshop_check_setup/defaults/main.yml
+++ b/provisioner/roles/workshop_check_setup/defaults/main.yml
@@ -1,1 +1,2 @@
+---
 use_manifest: false

--- a/provisioner/roles/workshop_check_setup/tasks/main.yml
+++ b/provisioner/roles/workshop_check_setup/tasks/main.yml
@@ -98,7 +98,7 @@
 
     - set_fact:
         tower_license: "{{ lookup('file',playbook_dir+'/tower_license.json')|from_json|combine({'eula_accepted':true}) }}"
-        default_tower_url:  "{{ default_tower37_url }}"
+        default_tower_url: "{{ default_tower37_url }}"
         use_manifest: false
       when: stat_result.stat.exists
 
@@ -113,7 +113,7 @@
 
 - set_fact:
     tower_license: "{{ tower_license_data|from_json|combine({'eula_accepted':true}) }}"
-    default_tower_url:  "{{ default_tower37_url }}"
+    default_tower_url: "{{ default_tower37_url }}"
   when:
     - towerinstall
     - tower_license is not defined

--- a/provisioner/roles/workshop_check_setup/tasks/main.yml
+++ b/provisioner/roles/workshop_check_setup/tasks/main.yml
@@ -76,25 +76,48 @@
   block:
     - name: Check that the provided license exists
       stat:
-        path: "{{playbook_dir}}/tower_license.json"
+        path: "{{ playbook_dir }}/manifest.zip"
+      register: manifest_result
+
+    - debug:
+        var: manifest_result
+
+    - name: Check that the provided license exists
+      stat:
+        path: "{{ playbook_dir }}/tower_license.json"
       register: stat_result
+
     - debug:
         var: stat_result
+
     - fail:
-        msg: "Need tower_license_data in extra_vars or a license located at {{playbook_dir}}/tower_license.json"
+        msg: "Need tower_license_data in extra_vars, a license located at {{ playbook_dir }}/tower_license.json, or a manifest file at {{ playbook_dir }}/manifest.zip"
       when:
         - not stat_result.stat.exists
+        - not manifest_result.stat.exists
+
     - set_fact:
         tower_license: "{{ lookup('file',playbook_dir+'/tower_license.json')|from_json|combine({'eula_accepted':true}) }}"
+        default_tower_url:  "{{ default_tower37_url }}"
+        use_manifest: false
+      when: stat_result.stat.exists
+
+    - set_fact:
+        use_manifest: true
+        default_tower_url: "{{ default_tower38_url }}"
+      when: manifest_result.stat.exists
+
   when:
     - towerinstall
     - tower_license_data is not defined
 
 - set_fact:
     tower_license: "{{ tower_license_data|from_json|combine({'eula_accepted':true}) }}"
+    default_tower_url:  "{{ default_tower37_url }}"
   when:
     - towerinstall
     - tower_license is not defined
+    - not use_manifest
 
 - name: Ensure tower license is not expired
   assert:
@@ -103,6 +126,7 @@
   ignore_errors: true
   when:
     - towerinstall
+    - not use_manifest
 
 - name: install product_demos collection
   shell: "{{item}}"


### PR DESCRIPTION
##### SUMMARY
Adds in code to look for a manifest.zip file, if found it will use it and AT 3.8, else it falls back to using the tower_license and AT 3.7

We should add code in to look for a tower_manifest variable also, incase we need to pass it in (base64 encoded ofcourse) that way.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
