### PR TITLE
Update main.yml

### DIFF
--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -7,6 +7,7 @@
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
     disable_gpg_check: true
+    validate_certs: false
 
 # temporary fix for rhel 8.2 dnf substitution
 - name: fix EPEL repo substitution

--- a/provisioner/tests/rhel_verify.yml
+++ b/provisioner/tests/rhel_verify.yml
@@ -21,6 +21,7 @@
             tower_host: "{{ inventory_hostname|regex_replace('-ansible-1', '') }}.{{ workshop_name }}.rhdemo.io"
             tower_username: admin
             tower_password: "{{ tower_password }}"
+            tower_verify_ssl: false
           register: export_assets
           until: export_assets is success
           delay: 3


### PR DESCRIPTION
##### SUMMARY
attemptiong to create workaround fix for CI testing

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
failures in CI testing are->
```
[2020-12-21T01:20:19.046Z] TASK [control_node : Install EPEL] *********************************************
[2020-12-21T01:20:40.956Z] fatal: [tqe-f5-tower373-1984-29-student1-ansible-1]: FAILED! => changed=false 
[2020-12-21T01:20:40.957Z]   msg: 'Failure downloading https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm, HTTP Error 403: Forbidden'
[2020-12-21T01:20:40.957Z]   results: []
[2020-12-21T01:20:42.851Z] fatal: [tqe-f5-tower373-1984-29-student2-ansible-1]: FAILED! => changed=false 
[2020-12-21T01:20:42.851Z]   msg: 'Failure downloading https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm, HTTP Error 403: Forbidden'
[2020-12-21T01:20:42.851Z]   results: []
```

but i can’t reproduce locally

task is

```
- name: Install EPEL
  dnf:
    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
    state: present
    disable_gpg_check: true
```
