### PR TITLE
creating option for auto shutoff for community grid

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -134,7 +134,7 @@
         - towerinstall|bool
         - populatetower
 
-- name: IBM community grid
+- name: IBM community grid managed nodes
   hosts: "managed_nodes"
   become: true
   gather_facts: true
@@ -143,6 +143,20 @@
     - name: install boinc-client and register
       include_role:
         name: community_grid
+      when:
+        - ibm_community_grid is defined
+        - ibm_community_grid
+
+- name: IBM community grid control node
+  hosts: "control_nodes"
+  become: true
+  gather_facts: true
+
+  tasks:
+    - name: install boinc-client and register
+      include_role:
+        name: community_grid
+        tasks_from: auto_shutoff
       when:
         - ibm_community_grid is defined
         - ibm_community_grid

--- a/provisioner/roles/community_grid/tasks/auto_shutoff.yml
+++ b/provisioner/roles/community_grid/tasks/auto_shutoff.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install ansible.cfg and vimrc in home directory
+- name: configure profile.d community_grid.sh
   template:
     src: auto_shutoff.j2
     dest: /etc/profile.d/community_grid.sh

--- a/provisioner/roles/community_grid/tasks/auto_shutoff.yml
+++ b/provisioner/roles/community_grid/tasks/auto_shutoff.yml
@@ -1,0 +1,5 @@
+---
+- name: Install ansible.cfg and vimrc in home directory
+  template:
+    src: auto_shutoff.j2
+    dest: /etc/profile.d/community_grid.sh

--- a/provisioner/roles/community_grid/templates/auto_shutoff.j2
+++ b/provisioner/roles/community_grid/templates/auto_shutoff.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+(nohup ansible-playbook /home/{{ username }}/{{ workshop_type }}-workshop//turn_off_community_grid.yml >/dev/null 2>&1 &)

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -7,7 +7,6 @@
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
     disable_gpg_check: true
-    validate_certs: false
 
 # temporary fix for rhel 8.2 dnf substitution
 - name: fix EPEL repo substitution


### PR DESCRIPTION
##### SUMMARY
creating option for auto shutoff for community grid using profile.d

basically someone who logs in via the SSH terminal (via vscode OR directly) it will fun a profile.d shell script, that auto kicks off the playbook that will shutoff community grid on any node that it is installed onto 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
will hopefully fix https://github.com/ansible/workshops/issues/1032