### PR TITLE
adding some fallback logic for when galaxy is down

### DIFF
--- a/provisioner/roles/workshop_check_setup/defaults/main.yml
+++ b/provisioner/roles/workshop_check_setup/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 use_manifest: false
+collections:
+  - awx.awx
+  - ansible.product_demos

--- a/provisioner/roles/workshop_check_setup/tasks/main.yml
+++ b/provisioner/roles/workshop_check_setup/tasks/main.yml
@@ -128,16 +128,29 @@
     - towerinstall
     - not use_manifest
 
-- name: install product_demos collection
-  shell: "{{item}}"
-  loop:
-    - "ansible-galaxy collection install ansible.product_demos --force-with-deps"
-    - "ansible-galaxy collection install awx.awx --force-with-deps"
-  register: galaxy
-  until: galaxy is not failed
-  retries: 5
-  when:
-    - towerinstall
+- name: install newest collections
+  vars:
+    collection_path: "{{ lookup('config', 'COLLECTIONS_PATHS')}}"
+  block:
+      - name: install product_demos collection
+        shell: "ansible-galaxy collection install {{item}} --force-with-deps "
+        loop: "{{ collections }}"
+        register: galaxy
+        until: galaxy is not failed
+        retries: 5
+        when:
+          - towerinstall
+  rescue:
+    - name: checking to see if older install collection is available
+      debug:
+        msg:
+          - "Looking at the following collection paths {{ collection_path }} "
+          - "only testing {{ collection_path|first }} "
+
+    - name: check if the collections exist
+      stat:
+        path: "{{ collection_path|first }}/{{ item | replace('.', '/') }}"
+      loop: "{{ collections }}"
 
 - name: check workshop specific information
   include_tasks: "{{item}}"

--- a/provisioner/roles/workshop_check_setup/tasks/main.yml
+++ b/provisioner/roles/workshop_check_setup/tasks/main.yml
@@ -132,14 +132,14 @@
   vars:
     collection_path: "{{ lookup('config', 'COLLECTIONS_PATHS')}}"
   block:
-      - name: install product_demos collection
-        shell: "ansible-galaxy collection install {{item}} --force-with-deps "
-        loop: "{{ collections }}"
-        register: galaxy
-        until: galaxy is not failed
-        retries: 5
-        when:
-          - towerinstall
+    - name: install product_demos collection
+      shell: "ansible-galaxy collection install {{item}} --force-with-deps "
+      loop: "{{ collections }}"
+      register: galaxy
+      until: galaxy is not failed
+      retries: 5
+      when:
+        - towerinstall
   rescue:
     - name: checking to see if older install collection is available
       debug:


### PR DESCRIPTION
##### SUMMARY
trying to fix https://github.com/ansible/workshops/issues/1011

this should fall back to a local install if ansible-galaxy is not responding, We are still on Ansible 2.9 so I don't have access to the `ansible-galaxy collection list <collection-name>` command yet 


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
this doesn't really help if you are using lots of random collection paths, but that is uncommon 
