### PR TITLE
fixes for certbot

### DIFF
--- a/provisioner/roles/aws_dns/tasks/tower.yml
+++ b/provisioner/roles/aws_dns/tasks/tower.yml
@@ -11,13 +11,11 @@
   until: change_base_url is not failed
   retries: 5
 
-# directions found here https://certbot.eff.org/lets-encrypt/centosrhel8-other
-- name: Download and install certbot
-  get_url:
-    url: https://dl.eff.org/certbot-auto
-    dest: /usr/local/bin/certbot-auto
-    mode: '0755'
-    owner: "root"
+- name: install certbot if not already installed
+  dnf:
+    name: certbot
+    state: present
+    disable_gpg_check: true
 
 # https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
 - name: turn off Ansible Tower
@@ -27,7 +25,7 @@
   block:
     # If this fails check out status of certbot: https://letsencrypt.status.io/
     - name: ISSUE CERT
-      shell: /usr/local/bin/certbot-auto certonly --no-bootstrap --standalone -d {{username}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
+      shell: certbot certonly --no-bootstrap --standalone -d {{username}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
       register: issue_cert
       until: issue_cert is not failed
       retries: 5

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -1,15 +1,4 @@
 ---
-# directions found here https://certbot.eff.org/lets-encrypt/centosrhel8-other
-- name: Download and install certbot
-  get_url:
-    url: https://dl.eff.org/certbot-auto
-    dest: /usr/local/bin/certbot-auto
-    mode: '0755'
-    owner: "root"
-  register: certbot_install
-  until: certbot_install is not failed
-  retries: 5
-
 - name: turn off tower
   shell: ansible-tower-service stop
 
@@ -31,9 +20,11 @@
     dest: /tmp/code-server.rpm
     mode: '0440'
 
-- name: install code-server 3 rpm from local rpm
+- name: install code-server 3 rpm from local rpm and certbot
   dnf:
-    name: /tmp/code-server.rpm
+    name:
+      - /tmp/code-server.rpm
+      - certbot
     state: present
     disable_gpg_check: true
 
@@ -116,8 +107,9 @@
     daemon_reload: true
     name: code-server
 
+# if we do not have a cert we will try to work anyway
 - name: issue cert
-  shell: /usr/local/bin/certbot-auto certonly --no-bootstrap --standalone -d {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
+  shell: certbot certonly --no-bootstrap --standalone -d {{username}}-code.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
   register: issue_cert
   until: issue_cert is not failed
   retries: 5

--- a/provisioner/roles/gitlab-server/tasks/certbot.yml
+++ b/provisioner/roles/gitlab-server/tasks/certbot.yml
@@ -37,22 +37,16 @@
       when:
         - ansible_distribution_major_version|int == 8
 
-    - name: GitLab post | IInstall base packages
+    - name: GitLab post | Install base packages
       dnf:
         name:
           - python3-pip
           - python3-devel
-
-    # directions found here https://certbot.eff.org/lets-encrypt/centosrhel8-other
-    - name: Download and install certbot
-      get_url:
-        url: https://dl.eff.org/certbot-auto
-        dest: /usr/local/bin/certbot-auto
-        mode: '0755'
-        owner: "root"
+          - certbot
+        disable_gpg_check: true
 
     - name: GitLab post | issue cert
-      shell: /usr/local/bin/certbot-auto certonly --no-bootstrap --standalone -d gitlab.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
+      shell: certbot certonly --no-bootstrap --standalone -d gitlab.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} --email ansible-network@redhat.com --noninteractive --agree-tos
       register: issue_cert
       until: issue_cert is not failed
       retries: 5


### PR DESCRIPTION
##### SUMMARY

ticket from Red Hat GPTE (Failures: Ansible Demos/Workshops - due to certbot-auto globally deprecated)

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
certbot changed the way they run
