### PR TITLE
Change to use minimum retries of 60 when waiting for ec2 instances

### DIFF
--- a/provisioner/roles/manage_ec2_instances/tasks/security_includes/security_ec2_create_instances.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/security_includes/security_ec2_create_instances.yml
@@ -206,7 +206,7 @@
   register: wait_for_ec2_instance_creation
   when: "'ansible_job_id' in item"
   until: wait_for_ec2_instance_creation.finished
-  retries: "{{ [async_wait_for_retries, 60] | max }}"
+  retries: "{{ [async_wait_for_retries | int, 60] | max }}"
   loop:
     - "{{siem_async}}"
     - "{{snort_async}}"

--- a/provisioner/roles/manage_ec2_instances/tasks/security_includes/security_ec2_create_instances.yml
+++ b/provisioner/roles/manage_ec2_instances/tasks/security_includes/security_ec2_create_instances.yml
@@ -206,7 +206,7 @@
   register: wait_for_ec2_instance_creation
   when: "'ansible_job_id' in item"
   until: wait_for_ec2_instance_creation.finished
-  retries: "{{ async_wait_for_retries }}"
+  retries: "{{ [async_wait_for_retries, 60] | max }}"
   loop:
     - "{{siem_async}}"
     - "{{snort_async}}"


### PR DESCRIPTION
##### SUMMARY

Set a minimum of 60 retries on waiting for ec2 instances. The current logic bases the number of retries on the student count, which does not make sense for instance creation. When set to a single student there are only 10 retries and the deployment often fails.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- provisioner