### PR TITLE
/etc/hosts updates

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -60,8 +60,8 @@
     - user_accounts
     - common
 
-- name: Configure cluster nodes with /etc/hosts
-  hosts: '*ansible-2,*ansible-3,*ansible-4'
+- name: Configure /etc/hosts
+  hosts: 'managed_nodes:control_nodes'
   gather_facts: true
   become: true
   tasks:
@@ -71,7 +71,6 @@
         dest: "/etc/hosts"
         owner: "{{ username }}"
         group: "{{ username }}"
-      when: create_cluster|bool
 
 - name: configure ansible control node
   hosts: '*ansible-1'

--- a/provisioner/roles/common/tasks/main.yml
+++ b/provisioner/roles/common/tasks/main.yml
@@ -14,8 +14,15 @@
     - sudo
     - common
 
+- name: setup /etc/hosts file per student
+  copy:
+    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
+    dest: "/etc/hosts"
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
 - hostname:
-    name: "{{short_name}}"
+    name: "{{short_name}}.example.com"
 
 - meta: flush_handlers
   tags:

--- a/provisioner/roles/common/tasks/main.yml
+++ b/provisioner/roles/common/tasks/main.yml
@@ -14,13 +14,6 @@
     - sudo
     - common
 
-- name: setup /etc/hosts file per student
-  copy:
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
-    dest: "/etc/hosts"
-    owner: "{{ username }}"
-    group: "{{ username }}"
-
 - hostname:
     name: "{{short_name}}.example.com"
 

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- hostname:
-    name: "{{short_name}}"
+#- hostname:
+#    name: "{{short_name}}.example.com"
 
 - name: Install packages
   include_tasks: package_dependencies.yml
@@ -16,13 +16,6 @@
   template:
     src: vimrc.j2
     dest: "/home/{{ username }}/.vimrc"
-    owner: "{{ username }}"
-    group: "{{ username }}"
-
-- name: setup /etc/hosts file per student
-  copy:
-    src: "{{ playbook_dir }}/{{ec2_name_prefix}}/{{ username }}-etchosts.txt"
-    dest: "/etc/hosts"
     owner: "{{ username }}"
     group: "{{ username }}"
 

--- a/provisioner/roles/control_node/tasks/main.yml
+++ b/provisioner/roles/control_node/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-#- hostname:
-#    name: "{{short_name}}.example.com"
-
 - name: Install packages
   include_tasks: package_dependencies.yml
 

--- a/provisioner/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
+++ b/provisioner/roles/manage_ec2_instances/templates/etchosts/etchosts_rhel.j2
@@ -3,26 +3,26 @@
 
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{ vm.tags.short_name }}
+{{ vm.private_ip_address }} {{ vm.tags.short_name }}.example.com {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node2_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 
 {% for vm in node3_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 
 {% if create_cluster %}
 {% for vm in isonode_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
@@ -30,13 +30,13 @@
 {% if create_cluster %}
 {% for vm in remotenode_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{vm.tags.short_name}}
+{{ vm.private_ip_address }} {{vm.tags.short_name}}.example.com {{ vm.tags.short_name }}
 {% endif %}
 {% endfor %}
 {% endif %}
 
 {% for vm in ansible_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}
-{{ vm.private_ip_address }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}} {{ vm.tags.short_name }}
+{{ vm.private_ip_address }} {{ vm.tags.short_name }}.example.com {{ vm.tags.short_name }} {{vm.tags.Student}}.{{ec2_name_prefix|lower}}.{{workshop_dns_zone}}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
Update /etc/hosts to use `{{short_name}}.example.com {{short_name}}`.
Deploy /etc/hosts to all nodes.
Hostname set to FQDN `{{short_name}}.example.com.`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
FQDN's will be required for smart management workshop. Change should not impact existing RHEL workshops but will reduce unique configurations across workshop types. 