### PR TITLE
Fixing TOC and Heading in exercise for network

### DIFF
--- a/exercises/ansible_network/1-explore/README.ja.md
+++ b/exercises/ansible_network/1-explore/README.ja.md
@@ -7,7 +7,6 @@
 - [Objective](#objective)
 - [Diagram](#diagram)
 - [Guide](#guide)
-- [Takeaways](#takeaways)
 
 # Objective
 

--- a/exercises/ansible_network/1-explore/README.md
+++ b/exercises/ansible_network/1-explore/README.md
@@ -7,7 +7,6 @@
 - [Objective](#objective)
 - [Diagram](#diagram)
 - [Guide](#guide)
-- [Takeaways](#takeaways)
 
 # Objective
 

--- a/exercises/ansible_network/3-facts/README.ja.md
+++ b/exercises/ansible_network/3-facts/README.ja.md
@@ -21,6 +21,8 @@ Ansible facts はリモートのネットワーク構成要素から取得され
 - [ios_facts モジュール](https://docs.ansible.com/ansible/latest/modules/ios_facts_module.html) の利用
 - [debug モジュール](https://docs.ansible.com/ansible/latest/modules/debug_module.html) の利用。
 
+# Guide
+
 #### Step 1
 
 コントローラーノード上で `ios_facts` モジュールと `debug` モジュールのドキュメントを確認します。


### PR DESCRIPTION
##### SUMMARY
* Deleted Takeaways from Table of contents, because there is not heading of Takeaways  in ansible exercise for network 1.
* Added heading of Guide in exercise for network 3. ( only Japanese page. ) 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
N/A