### PR TITLE
update hammer admin password

### DIFF
--- a/provisioner/smart_mgmt.yml
+++ b/provisioner/smart_mgmt.yml
@@ -15,6 +15,11 @@
   tasks:
     - name: configure satellite admin password
       command: "foreman-rake permissions:reset password={{ admin_password }}"
+    - name: update hammer admin password in /root/.hammer/cli.modules.d/foreman.yml
+      lineinfile:
+        path: /root/.hammer/cli.modules.d/foreman.yml
+        regexp: 'password'
+        line: "  :password: '{{ admin_password }}'"
     - name: configure satellite dns
       become: false
       route53:


### PR DESCRIPTION
##### SUMMARY
Currently, the smart_mgmt workshop provisioner does not update the /root/.hammer/cli.modules.d/foreman.yml file with the {{ admin_password }} during provisioning, which hampers any follow-up automation from utilizing the Satellite "hammer" utility.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION