### PR TITLE
fix CE testing for SSL failures

### DIFF
--- a/provisioner/roles/aws_dns/tasks/main.yml
+++ b/provisioner/roles/aws_dns/tasks/main.yml
@@ -25,9 +25,9 @@
     - name: certbot for Ansible Tower
       include_tasks: tower.yml
 
-    - name: turn on tower
+    - name: make sure Ansible Tower is started
       service:
-        name: turn on tower
+        name: ansible-tower.service
         state: started
       register: install_tower
       until: install_tower is not failed

--- a/provisioner/roles/aws_dns/tasks/main.yml
+++ b/provisioner/roles/aws_dns/tasks/main.yml
@@ -26,7 +26,9 @@
       include_tasks: tower.yml
 
     - name: turn on tower
-      shell: ansible-tower-service start
+      service:
+        name: turn on tower
+        state: started
       register: install_tower
       until: install_tower is not failed
       retries: 5

--- a/provisioner/roles/aws_dns/tasks/tower.yml
+++ b/provisioner/roles/aws_dns/tasks/tower.yml
@@ -1,7 +1,12 @@
 ---
 # https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
 - name: make sure Ansible Tower is online before changing tower base URL
-  shell: ansible-tower-service start
+  service:
+    name: turn on tower
+    state: started
+  register: install_tower
+  until: install_tower is not failed
+  retries: 5
 
 - name: install certbot if not already installed
   dnf:
@@ -23,7 +28,12 @@
 
 # https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
 - name: turn off Ansible Tower
-  shell: ansible-tower-service stop
+  service:
+    name: turn off tower
+    state: stopped
+  register: stop_tower
+  until: stop_tower is not failed
+  retries: 5
 
 - name: SSL cert block
   block:
@@ -56,7 +66,6 @@
       until: install_tower is not failed
       retries: 5
 
-    - name: fail on purpose
+    - name: no SSL cert for Ansible Tower
       debug:
-        msg: "failing on purpose - SSL cert problem"
-      failed_when: true
+        msg: "SSL cert problem - no cert applied"

--- a/provisioner/roles/aws_dns/tasks/tower.yml
+++ b/provisioner/roles/aws_dns/tasks/tower.yml
@@ -2,10 +2,10 @@
 # https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
 - name: make sure Ansible Tower is online before changing tower base URL
   service:
-    name: turn on tower
+    name: ansible-tower.service
     state: started
-  register: install_tower
-  until: install_tower is not failed
+  register: start_tower
+  until: start_tower is not failed
   retries: 5
 
 - name: install certbot if not already installed
@@ -27,9 +27,9 @@
   retries: 5
 
 # https://docs.ansible.com/ansible-tower/latest/html/administration/init_script.html
-- name: turn off Ansible Tower
+- name: make sure Ansible Tower is stopped
   service:
-    name: turn off tower
+    name: ansible-tower.service
     state: stopped
   register: stop_tower
   until: stop_tower is not failed
@@ -60,10 +60,12 @@
         src: combined_cert.j2
         dest: /etc/tower/tower.cert
   rescue:
-    - name: turn on tower
-      shell: ansible-tower-service start
-      register: install_tower
-      until: install_tower is not failed
+    - name: make sure Ansible Tower is started
+      service:
+        name: ansible-tower.service
+        state: started
+      register: start_tower
+      until: start_tower is not failed
       retries: 5
 
     - name: no SSL cert for Ansible Tower

--- a/provisioner/roles/code_server/tasks/codeserver.yml
+++ b/provisioner/roles/code_server/tasks/codeserver.yml
@@ -88,7 +88,7 @@
   retries: 5
   ignore_errors: true
 
-- name: modify nginx if cert is able to be issued
+- name: modify nginx to support code-server
   block:
     - name: update nginx configuration to support code server
       blockinfile:
@@ -117,8 +117,10 @@
         insertbefore: "include(.*)/etc/nginx/mime.types;"
         line: '{% raw %} {% endif %} {% endraw %}'
 
-- name: turn on tower
-  shell: ansible-tower-service start
+- name: make sure Ansible Tower is started
+  service:
+    name: ansible-tower.service
+    state: started
   register: install_tower
   until: install_tower is not failed
   retries: 5

--- a/provisioner/roles/code_server/tasks/main.yml
+++ b/provisioner/roles/code_server/tasks/main.yml
@@ -31,8 +31,10 @@
         state: absent
         insertafter: "http {"
 
-    - name: make sure tower is on
-      shell: ansible-tower-service start
+    - name: Smake sure tower is on
+      service:
+        name: ansible-tower.service
+        state: started
       register: install_tower
       until: install_tower is not failed
       retries: 5


### PR DESCRIPTION
##### SUMMARY
we should be able to fail SSL certs and still continue on
- got rid of shell commands for ansible tower on/off
- got rid of fail on purpose

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
cc @Spredzy 