### PR TITLE
Fixed return to Ansible for Windows Workshop

### DIFF
--- a/exercises/ansible_windows/1-tower/README.md
+++ b/exercises/ansible_windows/1-tower/README.md
@@ -261,4 +261,4 @@ The authentication settings are particularly important and you will need
 to review them and decide which method is best for your needs.
 
 <br><br>
-[Click here to return to the Ansible for Windows Workshop](../readme.md)
+[Click here to return to the Ansible for Windows Workshop](../README.md)


### PR DESCRIPTION
##### SUMMARY
Modfied Exercise 1 - Intro and configurations of Ansible Tower to redirect back to the ansible_windows page. Copied Exercise 2 links which is working 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- docs
