### PR TITLE
Change instruction to leave listen on port 8080

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -161,7 +161,7 @@ curl: (7) Failed to connect to node1 port 80: Connection refused
 </body>
 ```
 
-Feel free to change the httpd.conf file again and run the playbook.
+Leave the setting for listen on port 8080. We'll use this in a later exercise.
 
 ### Step 3 - Simple Loops
 


### PR DESCRIPTION
The current instruction left it to the attendee if they would like to
change the setting again after setting it to 8080. However, ex 1.7
has the attendee run a curl command to 8080 to check if the role worked.

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change line from "Feel free to change the httpd.conf file again and run the playbook." to "Leave the setting for listen on port 8080. We'll use this in a later exercise."
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1143 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
