### PR TITLE
Extend yamllint "truthy" with addition of allowed values: yes, no, on, off

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -12,3 +12,5 @@ rules:
     max-spaces-inside: 1
     level: error
   line-length: disable
+  truthy:
+    allowed-values: ['yes', 'no', 'true', 'false', 'on', 'off']


### PR DESCRIPTION
##### SUMMARY
Currently, any supported Ansible BOOLEANS value other than `true` or `false` produces a yamllint "truthy" error in Zuul. For example, utilizing a boolean in code: `wait: yes` ...results in a yamllint error:
`429:15    warning  truthy value should be one of [false, true]  (truthy)`
This PR is a request to extend the default yamllint "truthy" values `true` and `false` with addition of allowed values: `yes`, `no`, `on`, `off`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
[Ansible source code](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/parsing/convert_bool.py) indicates that `yes`, `no`, `on`, `off`, `true`, `false` are each acceptable as a BOOLEANS value. Additionally, performing a search on `yes no` in the ansible github repo shows that the integration tests primarily use `yes` or `no`. It seems that the automation code used to deploy these workshops should also be allowed to follow these best practices and not be limited to just `true` or `false`.
