### PR TITLE
Fix typo in expected output in RHEL exercise 1.5

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -157,7 +157,7 @@ Apache should now listen on port 8080. Easy enough to verify:
 curl: (7) Failed to connect to node1 port 80: Connection refused
 [student1@ansible ansible-files]$ curl http://node1:8080
 <body>
-<h1>This is a production webserver, take care!</h1>
+<h1>This is a development webserver, have fun!</h1>
 </body>
 ```
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes a mistake in the expected output in Ansible RHEL exercise 1.5, step 2

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
The output currently shows node1 as a production server, but in the previous exercise (1.4, step 1) it was designated as a development server. This is causing confusion for students as their own output does not match.
