### PR TITLE
[JP] fixed Japanese documents to follow the original English version

### DIFF
--- a/exercises/ansible_rhel/1.1-setup/README.ja.md
+++ b/exercises/ansible_rhel/1.1-setup/README.ja.md
@@ -26,7 +26,7 @@
 
 | Role                 | Inventory name |
 | ---------------------| ---------------|
-| Ansible Control Host | ansible        |
+| Ansible Control Host | ansible-1      |
 | Managed Host 1       | node1          |
 | Managed Host 2       | node2          |
 | Managed Host 3       | node3          |

--- a/exercises/ansible_rhel/1.2-adhoc/README.ja.md
+++ b/exercises/ansible_rhel/1.2-adhoc/README.ja.md
@@ -47,7 +47,7 @@ node2 ansible_host=<Y.Y.Y.Y>
 node3 ansible_host=<Z.Z.Z.Z>
 
 [control]
-ansible ansible_host=44.55.66.77
+ansible-1 ansible_host=44.55.66.77
 ```
 
 Ansible
@@ -70,7 +70,7 @@ Ansible
 
 ```bash
 [student<X@>ansible ~]$ ansible web  --list-hosts
-[student<X@>ansible ~]$ ansible web,ansible --list-hosts
+[student<X@>ansible ~]$ ansible web,control --list-hosts
 [student<X@>ansible ~]$ ansible 'node*' --list-hosts
 [student<X@>ansible ~]$ ansible all --list-hosts
 ```
@@ -130,7 +130,7 @@ node2 ansible_host=22.33.44.55
 node3 ansible_host=33.44.55.66
 
 [control]
-ansible ansible_host=44.55.66.77
+ansible-1 ansible_host=44.55.66.77
 ```
 
 > **ヒント**

--- a/exercises/ansible_rhel/1.5-handlers/README.ja.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.ja.md
@@ -61,7 +61,7 @@ node3 ansible_host=33.44.55.66
 node2 ansible_host=22.33.44.55
 
 [control]
-ansible ansible_host=44.55.66.77
+ansible-1 ansible_host=44.55.66.77
 ```
 
 次に、`~/ansible-files/` ディレクトリーのコントロールホストで `ftpserver.yml` ファイルを作成します。
@@ -221,9 +221,12 @@ Playbook と出力の概要:
 前述のように、ループはハッシュのリストでも実行できます。ユーザーを別の追加グループに割り当てる必要があると想像してください。
 
 ```yaml
-- username: dev_user groups: ftp
-- username: qa_user groups: ftp
-- username: prod_user groups: apache
+- username: dev_user
+  groups: ftp
+- username: qa_user
+  groups: ftp
+- username: prod_user
+  groups: apache
 ```
 
 `user` モジュールには、その他のユーザーを一覧表示するためのオプションのパラメーター `groups`

--- a/exercises/ansible_rhel/1.7-role/README.ja.md
+++ b/exercises/ansible_rhel/1.7-role/README.ja.md
@@ -24,7 +24,7 @@
 を作成することは可能ですが、最終的には複数のファイルを再利用して、整理することをお勧めします。
 
 これを行うには、Ansible Roles を使用します。ロールを作成するときは、Playbook
-を複数のパーツに分け、それらのパーツをディレクトリー構造に配置します。これについては、[ベストプラクティス](http://docs.ansible.com/ansible/playbooks_best_practices.html)
+を複数のパーツに分け、それらのパーツをディレクトリー構造に配置します。これについては、[ベストプラクティス](https://docs.ansible.com/ansible/2.9_ja/user_guide/playbooks_best_practices.html)
 で詳しく説明されています。
 
 この演習では、以下について説明します。

--- a/exercises/ansible_rhel/2.1-intro/README.ja.md
+++ b/exercises/ansible_rhel/2.1-intro/README.ja.md
@@ -42,7 +42,7 @@ Ansible Tower は、IT 自動化のためのエンタープライズソリュー
 
 | Role                         | Inventory name |
 | -----------------------------| ---------------|
-| Ansible Control Host & Tower | ansible        |
+| Ansible Control Host & Tower | ansible-1      |
 | Managed Host 1               | node1          |
 | Managed Host 2               | node2          |
 | Managed Host 2               | node3          |

--- a/exercises/ansible_rhel/2.2-cred/README.ja.md
+++ b/exercises/ansible_rhel/2.2-cred/README.ja.md
@@ -56,7 +56,7 @@ node2 ansible_host=33.44.55.66
 node3 ansible_host=44.55.66.77
 
 [control]
-ansible ansible_host=11.22.33.44
+ansible-1 ansible_host=11.22.33.44
 ```
 
 > **警告**


### PR DESCRIPTION
##### SUMMARY
Fixed Japanese documents to follow the original English version:

* Fixed inventory hostname from ansible to ansible-1 in control group
* Fixed wrong URL to the bestpractice page
* Fixed loop dict index to correct YAML format

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
N/A