### PR TITLE
Fix wrong best practice link in the 1.7-role

### DIFF
--- a/exercises/ansible_rhel/1.7-role/README.md
+++ b/exercises/ansible_rhel/1.7-role/README.md
@@ -19,7 +19,7 @@
 
 While it is possible to write a playbook in one file as we've done throughout this workshop, eventually you’ll want to reuse files and start to organize things.
 
-Ansible Roles are the way we do this.  When you create a role, you deconstruct your playbook into parts and those parts sit in a directory structure.  This is explained in more detail in the [best practice](http://docs.ansible.com/ansible/playbooks_best_practices.html).
+Ansible Roles are the way we do this.  When you create a role, you deconstruct your playbook into parts and those parts sit in a directory structure.  This is explained in more details in the [Tips and tricks](https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html) and the [Sample Ansible setup](https://docs.ansible.com/ansible/latest/user_guide/sample_setup.html).
 
 This exercise will cover:
 


### PR DESCRIPTION
##### SUMMARY
Fixed the best practice link in the `1.7-role` based on the latest documentation:

* The best practices has been moved to the Tips and Tricks.
* The description of the playbook directory structure has been changed to Sample Ansible setup.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
N/A