### PR TITLE
[ja] Fix wrong best practice links in the 1.7-role

### DIFF
--- a/exercises/ansible_rhel/1.7-role/README.ja.md
+++ b/exercises/ansible_rhel/1.7-role/README.ja.md
@@ -24,8 +24,7 @@
 を作成することは可能ですが、最終的には複数のファイルを再利用して、整理することをお勧めします。
 
 これを行うには、Ansible Roles を使用します。ロールを作成するときは、Playbook
-を複数のパーツに分け、それらのパーツをディレクトリー構造に配置します。これについては、[ベストプラクティス](https://docs.ansible.com/ansible/2.9_ja/user_guide/playbooks_best_practices.html)
-で詳しく説明されています。
+を複数のパーツに分け、それらのパーツをディレクトリー構造に配置します。これについては、 [Tips and tricks](https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html) および [Sample Ansible setup](https://docs.ansible.com/ansible/latest/user_guide/sample_setup.html) で詳しく説明されています。
 
 この演習では、以下について説明します。
 


### PR DESCRIPTION
##### SUMMARY

Fix wrong best practice links in the 1.7 role(Japanese version)

* Porting #1166 to Japanese docs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
N/A