### PR TITLE
Add GitHub cred type and manifest refresh ask - Smart Management workshop

### DIFF
--- a/provisioner/smart_mgmt.yml
+++ b/provisioner/smart_mgmt.yml
@@ -138,8 +138,8 @@
         credentials:
           - Satellite Credential
         extra_vars:
-          refresh_satellite_manifest: no
-        ask_variables_on_launch: yes
+          refresh_satellite_manifest: false
+        ask_variables_on_launch: true
       - name: SETUP / Tower
         project: Automated Management
         playbook: setup_tower.yml

--- a/provisioner/smart_mgmt.yml
+++ b/provisioner/smart_mgmt.yml
@@ -85,6 +85,22 @@
             FOREMAN_USER: "{% raw %}{{ '{{username}}' }}{% endraw %}"
             FOREMAN_PASSWORD: "{% raw %}{{ '{{password}}' }}{% endraw %}"
             FOREMAN_VALIDATE_CERTS: 'false'
+      - name: GitHub_Personal_Access_Token
+        description: Credential for GitHub repo operations automation
+        kind: cloud
+        inputs:
+          fields:
+            - type: string
+              id: personal_access_token
+              label: Personal Access Token
+              secret: true
+              help_text: GitHub Personal Access Token
+              multiline: true
+          required:
+            - personal_access_token
+        injectors:
+          env:
+            MY_PA_TOKEN: "{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}"  
     tower_credentials:
       - name: Satellite Credential
         credential_type: Satellite_Collection
@@ -121,6 +137,9 @@
         inventory: Workshop Inventory
         credentials:
           - Satellite Credential
+        extra_vars:
+          refresh_satellite_manifest: no
+        ask_variables_on_launch: yes
       - name: SETUP / Tower
         project: Automated Management
         playbook: setup_tower.yml

--- a/provisioner/smart_mgmt.yml
+++ b/provisioner/smart_mgmt.yml
@@ -100,7 +100,7 @@
             - personal_access_token
         injectors:
           env:
-            MY_PA_TOKEN: "{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}"  
+            MY_PA_TOKEN: "{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}"
     tower_credentials:
       - name: Satellite Credential
         credential_type: Satellite_Collection


### PR DESCRIPTION
##### SUMMARY
Add GitHub credential type to base Smart Management workshop deployment, as well as Satellite manifest refresh extra_var "ask" for initial Satellite job template runs

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
- GitHub Personal Access Token credential type addition is not currently required but makes it easier for future workshop options/needs.
- For the "SETUP / Satellite" job template, adding an extra_var that defaults to false, however, requires an ask/prompt to confirm before running makes it easier to support scenarios where a Satellite manifest refresh is required from the outset of the workshop.

