### PR TITLE
disabling community_grid by default

### DIFF
--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -40,7 +40,7 @@ security_console: qradar
 valid_security_console_types:
   - splunk
   - qradar
-ibm_community_grid: true
+ibm_community_grid: false
 create_cluster: false
 default_tower38_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.8.0-1.tar.gz
 default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.7.3-1.tar.gz


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Trying to alleviate issues from #1183 by disabling `community_grid` by default on the rhel nodes in tower inventory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
