### PR TITLE
fix wrong simulation attack ip

### DIFF
--- a/exercises/ansible_security/2.1-enrich/README.fr.md
+++ b/exercises/ansible_security/2.1-enrich/README.fr.md
@@ -29,7 +29,7 @@ Ensuite, comme il s'agit d'un atelier de sécurité, nous avons besoin d'un traf
 
   tasks:
     - name: simulate attack every 5 seconds
-      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip2'] }}/web_attack_simulation"
+      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip'] }}/web_attack_simulation"
 ```
 <!-- {% endraw %} -->
 

--- a/exercises/ansible_security/2.1-enrich/README.ja.md
+++ b/exercises/ansible_security/2.1-enrich/README.ja.md
@@ -33,7 +33,7 @@ VS Code オンラインエディターで、以下のコンテンツを含むホ
 
   tasks:
     - name: simulate attack every 5 seconds
-      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip2'] }}/web_attack_simulation"
+      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip'] }}/web_attack_simulation"
 ```
 <!-- {% endraw %} -->
 

--- a/exercises/ansible_security/2.1-enrich/README.md
+++ b/exercises/ansible_security/2.1-enrich/README.md
@@ -29,7 +29,7 @@ Next, since this is a security lab, we do need suspicious traffic - an attack. W
 
   tasks:
     - name: simulate attack every 5 seconds
-      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip2'] }}/web_attack_simulation"
+      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip'] }}/web_attack_simulation"
 ```
 <!-- {% endraw %} -->
 


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Preparing a demo I observed that following instructions in exercises/ansible_security/2.1-enrich/ I observed that when I daemonized to simulate the attack in the log there is no trace of the curl command.

Changing the ip that is being used to simulate the attack solves the issue.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
