### PR TITLE
Add workshop collection to requirements file

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -16,6 +16,8 @@ collections:
     version: 1.2.7
   - name: ansible.windows
     version: 1.5.0
+  - name: ansible.workshops
+    version: 0.0.3
   - name: chocolatey.chocolatey
     version: 1.1.0
   - name: cisco.ios


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change in provision_lab and other playbooks now refer to the workshops roles by FQCN. Provisioning fails when it can't find the roles. Adding the ansible.workshops collection to the requirements.yml file.

Note: specifying 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following is working from the devel branch.

Running provision_lab.yml, after having run ansible-galaxy collection install -r requirements.yml in the workshops directory.
```
[ec2-user@ip-172-31-1-111 provisioner]$ ansible-playbook provision_lab.yml -e @extra_vars_wintest.yml
[WARNING]: Skipping callback plugin 'time', unable to load

PLAY [Perform Checks to make sure this Playbook will complete successfully] **************************

TASK [Gathering Facts] *******************************************************************************
ok: [localhost]

TASK [run pre-check role to make sure workshop will complete provisioning] ***************************
ERROR! the role 'ansible.workshops.workshop_check_setup' was not found in /home/ec2-user/workshops/provisioner/roles:/home/ec2-user/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/home/ec2-user/workshops/provisioner

The error appears to be in '/home/ec2-user/workshops/provisioner/provision_lab.yml': line 10, column 15, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

      include_role:
        name: ansible.workshops.workshop_check_setup
              ^ here

PLAY RECAP *******************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
After adding ansible.workshops to the requirements file and rerunning install, provisioning succeeded.

Note the version is set to 0.0.3, not the current 0.0.4. This is due to the following dependency error when I tried 0.0.4.
```
ERROR! Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* awx.awx:19.0.0 (direct request)
* awx.awx:19.2.2 (dependency of ansible.workshops:0.0.4)
```
tox test passed.
```
(ansible) dpullman@dpullman-macos ansible-workshops % tox -e linters
linters recreate: /Users/dpullman/Documents/Projects/ansible-workshops/.tox/linters
linters installdeps: -r/Users/dpullman/Documents/Projects/ansible-workshops/test-requirements.txt
linters installed: pathspec==0.8.1,PyYAML==5.4.1,yamllint==1.26.1
linters run-test-pre: PYTHONHASHSEED='2912178322'
linters run-test: commands[0] | yamllint -s .
______________________________________________ summary _______________________________________________
  linters: commands succeeded
  congratulations :)
```
