### PR TITLE
Add h1 tag in template file of ansible_windows/6-roles/

### DIFF
--- a/exercises/ansible_windows/5-adv-playbook/README.fr.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.fr.md
@@ -141,7 +141,7 @@ Vous devriez maintenant avoir un éditeur ouvert dans le volet droit qui pourra 
     <body>
 
       <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
     </body>
     </html>

--- a/exercises/ansible_windows/5-adv-playbook/README.ja.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.ja.md
@@ -127,7 +127,7 @@ Playbook のプレイの中にいくつかの変数を定義します。これ�
 <body>
 
   <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-  <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+  <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
 </body>
 </html>

--- a/exercises/ansible_windows/5-adv-playbook/README.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.md
@@ -175,7 +175,7 @@ for creating your template. Enter the following details:
     <body>
 
       <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
     </body>
     </html>

--- a/exercises/ansible_windows/6-roles/README.fr.md
+++ b/exercises/ansible_windows/6-roles/README.fr.md
@@ -212,7 +212,7 @@ Cliquez avec le bouton droit sur `roles\iis_simple\templates` et créez un nouve
     <body>
 
       <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
     </body>
     </html>

--- a/exercises/ansible_windows/6-roles/README.ja.md
+++ b/exercises/ansible_windows/6-roles/README.ja.md
@@ -200,7 +200,7 @@ index.htmlテンプレートを追加します。
 <body>
 
   <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-  <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+  <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
 </body>
 </html>

--- a/exercises/ansible_windows/6-roles/README.md
+++ b/exercises/ansible_windows/6-roles/README.md
@@ -238,7 +238,7 @@ Right-click `roles\iis_simple\templates` and create a new file called
     <body>
 
       <p align=center><img src='http://docs.ansible.com/images/logo.png' align=center>
-      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}
+      <h1 align=center>{{ ansible_hostname }} --- {{ iis_test_message }}</h1>
 
     </body>
     </html>


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY

Added closing h1 tag `</h1>` in the template file.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
