### PR TITLE
Removing the need for pip, removed keyword bash from script for prope…

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -15,9 +15,17 @@ Here are the setup directions you have to perform one time for the [../provision
 
   - New to AWS and not sure what this step means?  [Click here](aws-directions/AWSHELP.md)
 
-3. Install the following packages using pip
+3. Install the following packages using dnf
 
-        pip install boto boto3 netaddr passlib pywinrm requests requests-credssp
+```
+[root@centos ~]# dnf install python3-boto \
+python3-boto3 \
+python3-netaddr \
+python3-passlib \
+python3-pywinrm \
+python3-requests \
+python3-requests-credssp
+```
 
   **Are you using Tower?**  [Tower Instructions](#tower-instructions)
 
@@ -35,11 +43,11 @@ aws_secret_access_key = ABCDEFGHIJKLMNOP/ABCDEFGHIJKLMNOP
 If you haven't done so already make sure you have the repo cloned to the machine executing the playbook
 
         git clone https://github.com/ansible/workshops.git
-        cd workshops/provisioner
+        cd workshops/
 
 6. Run the requirements.yml file to ensure all the Ansible collection prerequisites are met.
 ￼
-￼```bash
+￼```
 ￼ansible-galaxy collection install -r requirements.yml
 ￼```
 


### PR DESCRIPTION
…r display, requirements.yml exists in workshop dir not provisioner dir

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- docs


##### ADDITIONAL INFORMATION
Small fixes to the setup.sh
* Remove the need to use pip
* Made sure user was in correct dir to install requirements.yml
* Removed keyword from bash that was making output look odd in github. 
