### PR TITLE
Adding default ansible-navigator.yml to control node

### DIFF
--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -47,3 +47,4 @@ default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-to
 automation_hub: false
 default_platform_url: "https://drive.google.com/file/d/18DhQlWHS0pinc20wMscXKH1mTS_u1ve9/view?usp=sharing"
 aap_dir: "/home/{{ username }}/aap_install"
+ee_image: ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0

--- a/roles/control_node/tasks/all_workshop.yml
+++ b/roles/control_node/tasks/all_workshop.yml
@@ -20,6 +20,13 @@
     group: "{{ username }}"
     state: directory
 
+- name: Install ansible-navigator.yml in home directory
+  template:
+    src: ansible-navigator.yml.j2
+    dest: "/home/{{ username }}/.ansible-navigator.yml"
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
 # This may look redundant, but you can't put these in a loop because the
 # ansible_user will not be templated the way you expect when running under
 # Controller/AWX

--- a/roles/control_node/templates/ansible-navigator.yml.j2
+++ b/roles/control_node/templates/ansible-navigator.yml.j2
@@ -1,0 +1,20 @@
+---
+ansible-navigator:
+  ansible:
+    inventories:
+    - /home/{{username}}/lab_inventory/hosts
+
+  execution-environment:
+    enabled: true
+    container-engine: podman
+    image: {{ ee_image }}
+    pull-policy: missing
+
+  logging:
+    file: /home/{{username}}/.ansible-navigator/logs/ansible-navigator.log
+
+  playbook-artifact:
+    enable: True
+    replay: /tmp/artifact.json
+    save-as: /tmp/artifact.json
+


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Need to add a default ansible-navigator.yml file for the RHEL workshops. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
I gave a explicit version for the images which is the current default. Unsure if we want to make this a variable? Not sure how much it matters. 
