### PR TITLE
Adding the AAP repo role into workshops

### DIFF
--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -4,7 +4,7 @@ code_server: true
 workshop_dns_zone: "rhdemo.io"
 s3_state: "present"
 teardown: false
-controllerinstall: false
+controllerinstall: true
 populatecontroller: true
 website_information: ""
 login_website_information: ""
@@ -46,3 +46,4 @@ default_tower38_url: https://releases.ansible.com/ansible-tower/setup/ansible-to
 default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.7.3-1.tar.gz
 automation_hub: false
 default_platform_url: "https://drive.google.com/file/d/18DhQlWHS0pinc20wMscXKH1mTS_u1ve9/view?usp=sharing"
+aap_dir: "/home/{{ username }}/aap_install"

--- a/roles/aap_repo/tasks/create_repo.yml
+++ b/roles/aap_repo/tasks/create_repo.yml
@@ -1,0 +1,9 @@
+---
+- name: create repo
+  yum_repository:
+    name: aap_installer
+    description: aap_installer
+    baseurl: "file:///{{ aap_dir }}/bundle/el8/repos"
+    gpgcheck: no
+  become: true
+

--- a/roles/aap_repo/tasks/main.yml
+++ b/roles/aap_repo/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: create_repo.yml

--- a/roles/code_server/tasks/controller.yml
+++ b/roles/code_server/tasks/controller.yml
@@ -3,19 +3,19 @@
 - name: update Ansible installer nginx configuration template to support code server
   blockinfile:
     block: "{{ lookup('template', 'nginx.conf') }}"
-    dest: /tmp/aap_install/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf
+    dest: "{{ aap_dir }}/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf"
     insertafter: "http {"
 
 # Make the block inserted above conditional to only apply to ansible-1
 - name: Add jinja conditional start
   lineinfile:
-    path: /tmp/aap_install/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf
+    path: "{{ aap_dir }}/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf"
     insertafter: "http {"
     line: '{% raw %} {% if ansible_hostname == "ansible-1" %} {% endraw %}'
 
 # Make the block inserted above conditional to only apply to ansible-1
 - name: Add jinja conditional end
   lineinfile:
-    path: /tmp/aap_install/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf
+    path: "{{ aap_dir }}/collections/ansible_collections/ansible/automation_platform_installer/roles/nginx/templates/nginx.conf"
     insertbefore: "include(.*)/etc/nginx/mime.types;"
     line: '{% raw %} {% endif %} {% endraw %}'

--- a/roles/control_node/tasks/controller.yml
+++ b/roles/control_node/tasks/controller.yml
@@ -1,22 +1,34 @@
 ---
+- name: Create tmp directory to store AAP tar.gz
+  tempfile:
+    state: directory
+    suffix: "aapbundle"
+  register: tempdir
+
 - name: copy AAP tar.gz
   copy:
     src: '{{ playbook_dir }}/aap.tar.gz'
-    dest: /tmp/aap.tar.gz
+    dest: "{{ tempdir.path }}/aap.tar.gz"
 
 - name: Create directory for automation controller
-  file: path=/tmp/aap_install state=directory
+  file: 
+    path: "{{ aap_dir }}"
+    state: directory
 
 - name: Extract AAP tar.gz install
   unarchive:
-    src: /tmp/aap.tar.gz
-    dest: /tmp/aap_install
+    src: "{{ tempdir.path }}/aap.tar.gz"
+    dest: "{{ aap_dir }}"
     remote_src: true
     extra_opts: ['--strip-components=1', '--show-stored-names']
 
+- name: Set AAP local repository on controller node
+  include_role:
+    name: ansible.workshops.aap_repo
+
 - name: read in inventory data to determine if tower or controller
   slurp:
-    src: "/tmp/aap_install/inventory"
+    src: "{{ aap_dir }}/inventory"
   register: file_contents
 
 - name: controller or tower
@@ -26,20 +38,20 @@
 - name: template inventory file for Ansible Controller Install
   template:
     src: "{{ controller_or_tower }}_install.j2"
-    dest: /tmp/aap_install/inventory
+    dest: "{{ aap_dir }}/inventory"
   when: create_cluster is not defined or not create_cluster|bool
 
 - name: template inventory file for Automation Controller Install
   template:
     src: tower_cluster_install.j2
-    dest: /tmp/aap_install/inventory
+    dest: "{{ aap_dir }}/inventory"
   when: create_cluster is defined and create_cluster|bool
 
 # sean note to self... should I remove the gpgcheck=0?
 - name: run the Automation Controller installer
   shell: "./setup.sh -e gpgcheck=0"
   args:
-    chdir: /tmp/aap_install
+    chdir: "{{ aap_dir }}"
   async: 1400
   poll: 15
 


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Adding the AAP repo role into workshops so we have access to install ansible-navigator, ansible-builder etc via dnf

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


