### PR TITLE
Fixes logging in and pulling podman images as awx and student user, f…

### DIFF
--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -47,4 +47,3 @@ default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-to
 automation_hub: false
 default_platform_url: "https://drive.google.com/file/d/18DhQlWHS0pinc20wMscXKH1mTS_u1ve9/view?usp=sharing"
 aap_dir: "/home/{{ username }}/aap_install"
-ee_image: ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0

--- a/roles/control_node/tasks/controller.yml
+++ b/roles/control_node/tasks/controller.yml
@@ -79,20 +79,22 @@
 ## Execution environments
 
 - name: Login to redhat registry
-  become_user: awx
+  become_user: "{{ item }}"
   containers.podman.podman_login:
     username: '{{ redhat_username }}'
     password: '{{ redhat_password }}'
     registry: registry.redhat.io
+  loop:
+  - awx
+  - "{{ username }}"
 
 - name: Pull an image
-  become_user: awx
+  become_user: "{{ item[0] }}"
   containers.podman.podman_image:
-    name: "{{ item }}"
-  loop:
-    - registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8
-    - registry.redhat.io/ansible-automation-platform-20-early-access/ee-29-rhel8
-    - registry.redhat.io/ansible-automation-platform-20-early-access/ee-minimal-rhel8
+    name: "{{ item[1] }}"
+  with_nested:
+  - [ "awx" , "{{ username }}" ]
+  - [ "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8" , "registry.redhat.io/ansible-automation-platform-20-early-access/ee-29-rhel8" , "registry.redhat.io/ansible-automation-platform-20-early-access/ee-minimal-rhel8" ]
 
 - name: create container registry credential
   awx.awx.credential:

--- a/roles/control_node/templates/ansible-navigator.yml.j2
+++ b/roles/control_node/templates/ansible-navigator.yml.j2
@@ -7,7 +7,6 @@ ansible-navigator:
   execution-environment:
     enabled: true
     container-engine: podman
-    image: {{ ee_image }}
     pull-policy: missing
 
   logging:


### PR DESCRIPTION
…ixes ansible-navigator template

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Fixes the issue where podman was only logging in and pulling images for the awx user. It now can pull for the student user as well. This also fixed an issue with setting the image for the ansible-navigator.yml. This turned out not needed and better omitted letting ansible-navigator use its default. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

