### PR TITLE
[fix-tower-teardown] Added check to make sure playbook will complete …

### DIFF
--- a/provisioner/teardown_lab.yml
+++ b/provisioner/teardown_lab.yml
@@ -1,4 +1,21 @@
 ---
+- name: Perform Checks to make sure this Playbook will complete successfully
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: true
+  tasks:
+    - name: build workshop into collection
+      shell: "ansible-galaxy collection build --verbose --force --output-path build/ {{ playbook_dir }}/.."
+
+    - name: install newly created collection
+      shell: "ansible-galaxy collection install --verbose --force-with-deps build/*.tar.gz"
+
+    - name: Delete content & directory
+      file:
+        state: absent
+        path: build
+
 - name: Destroy lab instances in AWS
   hosts: localhost
   connection: local


### PR DESCRIPTION
…successfully

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Using the latest Ansible Automation Platform/Tower 3.8.3 and Ansible 2.9.24, the provision_lab.yml playbook is able to successfully deploy a workshop.  However, teardown_lab.yml does not complete in Tower. It stops with error 'ERROR! the role 'ansible.workshops.aws_dns' was not found in ...' because teardown_lab.yml ASSUMES provision_lab was executed (and installed workshop collections) in the same environment. This fix adds the local collection installtion to teardown_lab.yml

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This is for anyone that wants to deploy a workshop from AAP/Tower in their private aws accounts. I submitted this as part of a project to automate workshop deployments into tower setup.  Everything works, except teardown.  ttps://github.com/syspimp/deploy-workshop-workstation

The reason for the error is provision_lab.yml installs the custom collection locally, and teardown_lab.yml ASSUMES the collections are installed and available locally.  Running in AAP/Tower virtual environments, this is NOT the case.  Tower does install the collections in the requirements.yml when adding the project, but provision_lab.yml installs the workshop collection.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Once can reproduce this error on a clean git clone of this workshop, configuring it, and then running teardown_lab.yml without running provision_lab.yml first.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
######BEFORE#########
TASK [include_role : ansible.workshops.aws_dns] **************************************************************************************************************
ERROR! the role 'ansible.workshops.aws_dns' was not found in /var/lib/awx/projects/workshops/provisioner/roles:/var/lib/awx/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:/var/lib/awx/projects/workshops/provisioner

The error appears to be in '/var/lib/awx/projects/workshops/provisioner/teardown_lab.yml': line 17, column 29, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - {include_role: {name: manage_ec2_instances}}
    - {include_role: {name: ansible.workshops.aws_dns}, when: dns_type == "aws"}


######AFTER#########
TASK [include_role : ansible.workshops.aws_dns] **************************************************************************************************************

TASK [ansible.workshops.aws_dns : remove dns entries for each tower node] ************************************************************************************
included: /var/lib/awx/.ansible/collections/ansible_collections/ansible/workshops/roles/aws_dns/tasks/teardown.yml for localhost

TASK [ansible.workshops.aws_dns : GRAB ZONE ID] **************************************************************************************************************
ok: [localhost]
#####################
```
