### PR TITLE
Make location iand name of aap tar archive a var and ansible tag it

### DIFF
--- a/roles/control_node/tasks/10_aap_setup.yml
+++ b/roles/control_node/tasks/10_aap_setup.yml
@@ -7,7 +7,7 @@
 
 - name: copy AAP tar.gz
   copy:
-    src: '{{ playbook_dir }}/aap.tar.gz'
+    src: "{{ aap_archive | default(playbook_dir + '/aap.tar.gz') }}"
     dest: "{{ tempdir.path }}/aap.tar.gz"
 
 - name: Create directory for automation controller

--- a/roles/control_node/tasks/main.yml
+++ b/roles/control_node/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: aap setup for control node
   include_tasks: 10_aap_setup.yml
+  tags:
+    - aap_setup
 
 - name: Install packages
   include_tasks: 15_package_dependencies.yml


### PR DESCRIPTION
##### SUMMARY

Make the location, and name, of the aap tar archive a var: `aap_archive` , benefits:

- No longer necessary to copy into the `playbook_dir`
- Name can carry alternative name including versioning number eg `aap_2.1.0.tar.gz`
- Allow for different payloads with same repo eg per workshop level versions 2.0 for prod, 2.1 for development (or by workshop type)
- tag allows `--skip-tags` during development as this can be time consuming

Preserves old behavior as default i.e. will look in playbook_dir

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- provisioner

##### ADDITIONAL INFORMATION

```
- name: copy AAP tar.gz
  copy:
    src: "{{ aap_archive | default(playbook_dir + '/aap.tar.gz') }}"
    dest: "{{ tempdir.path }}/aap.tar.gz"
```

and 

```
- name: aap setup for control node
  include_tasks: 10_aap_setup.yml
  tags:
    - aap_setup
```

