### PR TITLE
Add default `workshop_type` var to `control_node` role

### DIFF
--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 aap_dir: "/home/{{ username }}/aap_install"
 
+# Default workshop type used to determine default workshop execution environment
+workshop_type: rhel
+
 # workshop execution environments
 f5_ee: "quay.io/acme_corp/f5_ee:latest"
 security_ee: "quay.io/acme_corp/security_ee:latest"


### PR DESCRIPTION
##### SUMMARY
Add `workshop_type` default value to `control_node` role for Instruqt issue:
https://github.com/ansible/instruqt/issues/49

fixes #1281

##### ISSUE TYPE
- Bugfix Pull Request
