### PR TITLE
Add default value `ec2_name_prefix` var for Instruqt image builds

### DIFF
--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -4,6 +4,9 @@ aap_dir: "/home/{{ username }}/aap_install"
 # Default workshop type used to determine default workshop execution environment
 workshop_type: rhel
 
+# Default ec2 prefix needed for using role in Instruqt image builds
+ec2_name_prefix: TESTWORKSHOP
+
 # workshop execution environments
 f5_ee: "quay.io/acme_corp/f5_ee:latest"
 security_ee: "quay.io/acme_corp/security_ee:latest"


### PR DESCRIPTION
##### SUMMARY
fixes #1284
Added default value of "TESTWORKSHOP" for `ec2_name_prefox` var in the `control_node` role. 
Linked to Instruqt issue:
https://github.com/ansible/instruqt/issues/50

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- demos
