### PR TITLE
Ghpages build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ provisioner/tests/ci-common.yml
 *.gz
 provisioner/old_tower_license.json
 .cache/
+.jekyll-cache/

--- a/exercises/ansible_rhel_90/2-adhoc
+++ b/exercises/ansible_rhel_90/2-adhoc
@@ -1,1 +1,1 @@
-../ansible_rhel/1.2-adhoc
+../ansible_rhel/1.2-thebasics


### PR DESCRIPTION
##### SUMMARY
- Incorrect symlink stopped GH Pages from building successfully.
- Updated the symlink:
  - ../ansible_rhel/1.2-thebasics ==> 2-adhoc 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- exercises