### PR TITLE
syncing fixes for downloading from github

### DIFF
--- a/provisioner/group_vars/all/all.yml
+++ b/provisioner/group_vars/all/all.yml
@@ -44,3 +44,4 @@ create_cluster: false
 default_tower38_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.8.0-1.tar.gz
 default_tower37_url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-3.7.3-1.tar.gz
 automation_hub: false
+developer_mode: false

--- a/roles/code_server/tasks/codeserver.yml
+++ b/roles/code_server/tasks/codeserver.yml
@@ -75,6 +75,9 @@
     - https://github.com/ansible/workshops/raw/devel/files/hnw.vscode-auto-open-markdown-preview-0.0.4.vsix
     - https://github.com/ansible/workshops/raw/devel/files/redhat.ansible-0.4.5.vsix
     - https://github.com/ansible/workshops/raw/devel/files/ms-python.python-2021.9.1230869389.vsix
+  register: download_extension
+  until: download_extension is not failed
+  retries: 5
 
 - name: install ansible and markdown extensions
   become_user: "{{ username }}"


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
adding until loop 

```
- name: install ansible and markdown extensions
  become_user: "{{ username }}"
  command: "/bin/code-server --install-extension /home/{{ username }}/.local/share/code-server/extensions/{{ item }}"
  loop:
    - bierner.markdown-preview-github-styles-0.1.6.vsix
    - hnw.vscode-auto-open-markdown-preview-0.0.4.vsix
    - redhat.ansible-0.4.5.vsix
    - ms-python.python-2021.9.1230869389.vsix
  ignore_errors: true
  register: install_extension
  until: install_extension is not failed
  retries: 5
```


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
