### PR TITLE
Fixing the navigator selinux label issue

### DIFF
--- a/exercises/ansible_f5/1.0-explore/README.md
+++ b/exercises/ansible_f5/1.0-explore/README.md
@@ -131,7 +131,6 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
-      label: "Z"
 ```
 
 Note the following parameters within the `ansible-navigator.yml` file:

--- a/exercises/ansible_network/1-explore/README.md
+++ b/exercises/ansible_network/1-explore/README.md
@@ -138,7 +138,6 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
-      label: "Z"
 ```
 
 Note the following parameters within the `ansible-navigator.yml` file:

--- a/exercises/ansible_rhel/1.1-setup/README.md
+++ b/exercises/ansible_rhel/1.1-setup/README.md
@@ -129,7 +129,6 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
-      label: "Z"
 ```
 
 Note the following parameters within the `ansible-navigator.yml` file:

--- a/exercises/ansible_security/1.1-explore/README.md
+++ b/exercises/ansible_security/1.1-explore/README.md
@@ -159,7 +159,6 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
-      label: "Z"
 ```
 
 Note the following parameters within the `ansible-navigator.yml` file:

--- a/roles/control_node/templates/ansible-navigator.yml.j2
+++ b/roles/control_node/templates/ansible-navigator.yml.j2
@@ -12,4 +12,3 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
-      label: "Z"


### PR DESCRIPTION
Fixes #1417

Removes the label from the navigator settings for volume mounts, if not removed the issue is intermittent.