### PR TITLE
Update provision_lab.yml

### DIFF
--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -33,8 +33,12 @@
         - name: build workshop into collection
           shell: "ansible-galaxy collection build --verbose --force --output-path build/ {{ playbook_dir }}/.."
 
+        # - name: install newly created collection
+        #   shell: "ansible-galaxy collection install --verbose --force-with-deps build/*.tar.gz"
+
         - name: install newly created collection
-          shell: "ansible-galaxy collection install --verbose --force-with-deps build/*.tar.gz"
+          shell: "ansible-galaxy collection install --verbose --force-with-deps build/*.tar.gz -p {{ playbook_dir }}/workshop_collections"
+
 
         - name: Delete content & directory
           file:


### PR DESCRIPTION
##### SUMMARY
somehow the -p was missing in the provisioner.... (not sure how that happened)

this will force the collections into `provisioner/workshop_collections`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
this will help with provisioning when a control node has 2+ different versions of ansible.workshops going on at the same time
