### PR TITLE
Recommended changes that should enhance lab provisioner

### DIFF
--- a/roles/control_node/tasks/30_controller.yml
+++ b/roles/control_node/tasks/30_controller.yml
@@ -56,12 +56,22 @@
   debug:
     msg: '{{ check2.json }}'
 
-- name: install ansible-tower-cli and requests
+#- name: install ansible-tower-cli and requests
+#  become: true
+#  pip:
+#    name:
+#      - ansible-tower-cli
+#      - "requests==2.6.0"
+#    state: latest
+
+# Certbot dependancy / acme, needs later version of requests library than task above^^
+- name: install ansible-tower-cli and requests >2.14
   become: true
-  pip:
+  ansible.builtin.pip:
     name:
       - ansible-tower-cli
-      - "requests==2.6.0"
+      - "requests==2.14.2"
+    executable: '/usr/bin/pip3.6'
     state: latest
 
 - name: load license block

--- a/roles/control_node/templates/tower_cluster_install.j2
+++ b/roles/control_node/templates/tower_cluster_install.j2
@@ -1,4 +1,4 @@
-[tower]
+[automationcontroller]
 ansible-1
 ansible-2
 ansible-3

--- a/roles/populate_controller/tasks/network.yml
+++ b/roles/populate_controller/tasks/network.yml
@@ -26,6 +26,8 @@
     controller_password: "{{ admin_password }}"
     controller_host: "https://{{ ansible_host }}"
     validate_certs: false
+    galaxy_credentials:
+      - "Ansible Galaxy"
 
 - name: create compute organization
   awx.awx.organization:
@@ -36,6 +38,8 @@
     controller_password: "{{ admin_password }}"
     controller_host: "https://{{ ansible_host }}"
     validate_certs: false
+    galaxy_credentials:
+      - "Ansible Galaxy"
 
 # teams
 - name: create netops team


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
1:
.ansible/collections/ansible_collections/ansible/workshops/roles/control_node/templates/tower_cluster_install.j2

Rename group tower to automationcontroller

2:
TASK [ansible.workshops.issue_cert : Issue SSL cert]
pkg_resources.DistributionNotFound: The 'requests>=2.14.2' distribution was not found and is required by acme

"~/.ansible/collections/ansible_collections/ansible/workshops/roles/control_node/tasks/30_controller.yml

Modified tower-cli install. Replaced with this task to ensure a version of requests that is compatible with certbot.
Also note that workshop provisioner installs python3-pip so I have specified that for the executable.

# Certbot dependancy / acme, needs later version of requests library than task above^^
- name: install ansible-tower-cli and requests >2.6.  #requests V2.14.2 is required by certbot.
  become: true
  ansible.builtin.pip:
    name:
      - ansible-tower-cli
      - "requests==2.14.2"
    executable: '/usr/bin/pip3.6'
    state: latest

3:
/home/rhailsto/.ansible/collections/ansible_collections/ansible/workshops/roles/populate_controller/tasks/network.yml

    galaxy_credentials:
      - "Ansible Galaxy"

4:
Update template to point at new workshop exercises
./collections/ansible_collections/ansible/workshops/roles/workshop_attendance/templates/index.php.j2

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
The certbot process was failing due to a dependancy on the python requests library.
Ive modified so a later version gets installed.
Galaxy creds for the workshop oragnizations in the network workshop were missing and the exercise associated with RBAC was failing.
```
