### PR TITLE
check privilege escalation box before running the ad-hoc command

### DIFF
--- a/exercises/ansible_rhel/2.2-cred/README.md
+++ b/exercises/ansible_rhel/2.2-cred/README.md
@@ -100,7 +100,7 @@ Within the **Machine Credential** window, select **Workshop Credentials** and cl
 
 > **Tip**
 >
-> The output of the results is displayed once the command has completed. 
+> The output of the results is displayed once the command has completed.
 >
 
 <hr>
@@ -164,7 +164,7 @@ Okay, a small challenge: Run an ad hoc to make sure the package "tmux" is instal
 
 * Click **Run Command** button. In the next screen you have to specify the ad hoc command.
 
-Within the **Details** window, select **Module** `yum`, in **Arguments** type `name=tmux` and click **Next**.
+Within the **Details** window, select **Module** `yum`, in **Arguments** type `name=tmux`, check **Enable privilege escalation** and click **Next**.
 
 Within the **Execution Environment** window, select **Default execution environment** and click **Next**.
 


### PR DESCRIPTION
##### SUMMARY
The challenge lab on ad-hoc commands is missing the check box "Enable privilege escalation" in the solution.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises
 
##### ADDITIONAL INFORMATION
Without privilege escalation the yum installation will fail due to missing privileges.
