### PR TITLE
Feature provisioner extra vars

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -85,6 +85,9 @@ controllerinstall: true
 # forces ansible.workshops collection to install latest edits every time
 developer_mode: true
 
+# SHA value of targeted AAP bundle setup files. Default AAP 2.1 bundle setup
+provided_sha_value: ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01
+
 # default vars for ec2 AMIs (ec2_info) are located in provisioner/roles/manage_ec2_instances/defaults/main/main.yml
 # select ec2_info AMI vars can be overwritten via ec2_xtra vars, e.g.:
 ec2_xtra:

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -88,6 +88,9 @@ developer_mode: true
 # SHA value of targeted AAP bundle setup files. Default AAP 2.1 bundle setup
 provided_sha_value: ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01
 
+# Automation controller install setup command. Default: "./setup.sh -e gpgcheck=0" if undefined or empty
+controller_install_command: './setup.sh -e gpgcheck=0'
+
 # default vars for ec2 AMIs (ec2_info) are located in provisioner/roles/manage_ec2_instances/defaults/main/main.yml
 # select ec2_info AMI vars can be overwritten via ec2_xtra vars, e.g.:
 ec2_xtra:

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -85,7 +85,7 @@ controllerinstall: true
 # forces ansible.workshops collection to install latest edits every time
 developer_mode: true
 
-# SHA value of targeted AAP bundle setup files. Default AAP 2.1 bundle setup
+# SHA value of targeted AAP bundle setup files.
 provided_sha_value: ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01
 
 # Automation controller install setup command. Default: "./setup.sh -e gpgcheck=0" if undefined or empty

--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -9,3 +9,6 @@ network_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-s
 rhel_90_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
 windows_ee: "quay.io/acme_corp/windows_ee:latest"
 smart_mgmt_ee: "quay.io/s4v0/ee-automated-smart-mgmt-29:1.0.4"
+
+# Controller install command
+controller_install_command: "./setup.sh -e gpgcheck=0"

--- a/roles/control_node/tasks/30_controller.yml
+++ b/roles/control_node/tasks/30_controller.yml
@@ -13,7 +13,7 @@
 
 # sean note to self... should I remove the gpgcheck=0?
 - name: run the Automation Controller installer
-  shell: "./setup.sh -e gpgcheck=0"
+  shell: "{{ controller_install_command }}"
   args:
     chdir: "{{ aap_dir }}"
   async: 1400


### PR DESCRIPTION
##### SUMMARY

- **Added ```controller_install_command``` var**
  - ```controller_install_command``` var lets you customize the controller installer command. Useful for testing
- **Added ```provided_sha_value``` example in README.**
  -  ```provided_sha_value``` determines AAP version installed. 
  - Added an example to ```extra_vars.yml``` docs 
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
