### PR TITLE
Add support for locally cached install bundle (fixes #1453)

### DIFF
--- a/roles/aap_download/tasks/main.yml
+++ b/roles/aap_download/tasks/main.yml
@@ -1,18 +1,20 @@
 ---
+- name: check if aap.tar.gz exists
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/aap.tar.gz"
+    checksum_algorithm: sha256
+  register: stat_var
+
 - name: attempt to download specified AAP
   block:
     - name: setup control node for workshop type
       include_tasks: 10_download.yml
+  when: not stat_var.stat.exists or (stat_var.stat.exists and (stat_var.stat.checksum != provided_sha_value))
 
   rescue:
     - name: aap_download role has entered rescue stanza
       debug:
         msg: "download from access.redhat.com has failed, attempting to see if there is a cached aap.tar.gz file"
-
-    - name: check if aap.tar.gz exists
-      ansible.builtin.stat:
-        path: "{{ playbook_dir }}/aap.tar.gz"
-      register: stat_var
 
     - name: fail if file aap.tar.gz not found
       fail:


### PR DESCRIPTION
##### SUMMARY
Fixes #1453 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
I have tested the following scenarios locally to verify correct behavior:
1) provisioner/aap.tar.gz not present - API token process completes and correct version of install bundle is downloaded
2) provisioner/aap.tar.gz is present and correct version - API token process and download process are skipped
3) provisioner/aap.tar.gz is present and incorrect version - API token process completes, correct version of install bundle is downloaded and replaces previous version of locally cached install bundle