### PR TITLE
Updating workshop AAP to use latest AAP 2.1 GA

### DIFF
--- a/roles/aap_download/defaults/main.yml
+++ b/roles/aap_download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-# 2021-09-27
-provided_sha_value: 9e95a63b6fbc65fcf037ad5a7ea939883b57662a3df6b7468f6b91e1003d91b3
+# December-2021
+provided_sha_value: ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01


### PR DESCRIPTION
##### SUMMARY
Update download aap.tar.gz to AAP 2.1 GA. Currently it uses early release candidate as the default download. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

