### PR TITLE
Automated Smart Management - implement workshop, demo or playground modes

### DIFF
--- a/provisioner/smart_mgmt.yml
+++ b/provisioner/smart_mgmt.yml
@@ -146,3 +146,168 @@
         loop_var: controller_infra_vars
       when:
         - controller_infra_workloads | d("") | length >0
+
+- name: Final workshop preparations
+  hosts: control_nodes
+  become: true
+  gather_facts: true
+
+  tasks:
+
+    - block:
+      - name: Run SETUP / Satellite job template
+        awx.awx.job_launch:
+          job_template: "SETUP / Satellite"
+          extra_vars:
+            refresh_satellite_manifest: true
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: setupsatjob
+
+      - name: "Check API until SETUP / Satellite job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ setupsatjob.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates01
+        until: workshop_job_templates01.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+
+      when: provision_mode == "workshop"
+
+    - block:
+      - name: Run SETUP / Satellite job template
+        awx.awx.job_launch:
+          job_template: "SETUP / Satellite"
+          extra_vars:
+            refresh_satellite_manifest: true
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: setupsatjob
+
+      - name: "Check API until SETUP / Satellite job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ setupsatjob.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates01
+        until: workshop_job_templates01.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+
+      - name: Run SETUP / Controller job template
+        awx.awx.job_launch:
+          job_template: "SETUP / Controller"
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: setupcontroljob
+
+      - name: "Check API until SETUP / Controller job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ setupcontroljob.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates02
+        until: workshop_job_templates02.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+
+      - name: Run SATELLITE / RHEL - Publish Content View job template
+        awx.awx.job_launch:
+          job_template: "SATELLITE / RHEL - Publish Content View"
+          extra_vars:
+            env: Dev
+            content_view: RHEL7
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: rhelpubcvjob01
+
+      - name: "Check API until SATELLITE / RHEL - Publish Content View job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ rhelpubcvjob01.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates03
+        until: workshop_job_templates03.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+
+      - name: Run SATELLITE / RHEL - Promote Content View job template
+        awx.awx.job_launch:
+          job_template: "SATELLITE / RHEL - Promote Content View"
+          extra_vars:
+            content_view: RHEL7
+            current_lifecycle_environment: RHEL7_Dev
+            lifecycle_environment: RHEL7_QA
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: rhelpromotecvjob01
+
+      - name: "Check API until SATELLITE / RHEL - Promote Content View job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ rhelpromotecvjob01.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates04
+        until: workshop_job_templates04.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+
+      - name: Run SATELLITE / RHEL - Publish Content View job template
+        awx.awx.job_launch:
+          job_template: "SATELLITE / RHEL - Publish Content View"
+          extra_vars:
+            env: Dev
+            content_view: RHEL7
+          controller_username: admin
+          controller_password: "{{ admin_password }}"
+          controller_host: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}"
+        register: rhelpubcvjob02
+
+      - name: "Check API until SATELLITE / RHEL - Publish Content View job is successful"
+        ansible.builtin.uri:
+          url: "https://{{ username }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/api/v2/jobs/{{ rhelpubcvjob02.id }}/?format=json"
+          user: admin
+          password: "{{ admin_password }}"
+          force_basic_auth: true
+          method: GET
+          return_content: true
+          status_code: 200
+          validate_certs: false
+        register: workshop_job_templates05
+        until: workshop_job_templates05.json.status == "successful"
+        delay: 20 # Every 20 seconds
+        retries: 180 # 1hour 60*60/20
+        
+      when: provision_mode == "demo"


### PR DESCRIPTION
##### SUMMARY
Implements functionality for #1463  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
When deploying the Automated Smart Management scenario `smart_mgmt`, set the variable `provision_mode` in the deployment extra_vars file. The following choices are available for which deployment mode to utilize:
```
provision_mode: workshop
```
For workshop mode, after the Satellite node is rolled out, the Controller will execute the `SETUP / Satellite` job template, saving approximately 30-45 minutes of execution time for workshop attendees.

```
provision_mode: demo
```
For demo mode, after the Satellite node is rolled out, the Controller will execute the `SETUP / Satellite` job template, the `SETUP / Controller` job template, as well as a series of additional job templates, all to completely ready the Controller and Satellite for demo usage, saving approximately an hour of pre-demo setup time.

```
provision_mode: playground
```
For playground mode, no post roll out configuration is performed, leaving both the Satellite and Controller available for full customization.
