### PR TITLE
fixing so it will download faster and check sha256

### DIFF
--- a/roles/aap_download/tasks/10_download.yml
+++ b/roles/aap_download/tasks/10_download.yml
@@ -18,36 +18,6 @@
 #   debug:
 #     var: temp_token.json.access_token
 
-# deprecating this task, this SHA value can be found on access.redhat.com next to the imate name
-# - name: retrieving SHA for AAP download
-#   uri:
-#     url: https://api.access.redhat.com/management/v1/images/cset/{{ app_image }}
-#     headers:
-#       Content-Type: "application/json"
-#       Authorization: "Bearer {{ temp_token.json.access_token }}"
-#     method: GET
-#     body_format: form-urlencoded
-#     return_content: true
-#   register: sha_value
-
-# - name: display SHA checksum
-#   debug:
-#     var: sha_value
-
-# - name: display SHA checksum
-#   debug:
-#     var: sha_value.json.body[1].checksum
-
-# - name: retrieving download link via sha_value
-#   uri:
-#     url: https://api.access.redhat.com/management/v1/images/{{ sha_value.json.body[1].checksum }}/download
-#     headers:
-#       accept: "application/json"
-#       Authorization: "Bearer {{ temp_token.json.access_token }}"
-#     method: GET
-#   register: download_url
-#   failed_when: "'bundle' not in sha_value.json.body[1].filename"
-
 - name: retrieving download link via sha_value
   uri:
     url: https://api.access.redhat.com/management/v1/images/{{ provided_sha_value }}/download

--- a/roles/aap_download/tasks/main.yml
+++ b/roles/aap_download/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: check if aap.tar.gz exists
-  ansible.builtin.stat:
+  stat:
     path: "{{ playbook_dir }}/aap.tar.gz"
     checksum_algorithm: sha256
   register: stat_var
@@ -18,5 +18,16 @@
 
     - name: fail if file aap.tar.gz not found
       fail:
-        msg: "This host has already had this playbook run against it"
+        msg: "There was no app.tar.gz file found to install AAP"
       when: not stat_var.stat.exists
+
+- name: check if aap.tar.gz again (post download)
+  stat:
+    path: "{{ playbook_dir }}/aap.tar.gz"
+    checksum_algorithm: sha256
+  register: stat_var
+
+- name: Verify sha256sum of aap.tar.gz
+  fail:
+    msg: "Failure, sha256sum does not match"
+  when: stat_var.stat.checksum != provided_sha_value

--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -17,7 +17,7 @@ ee_registry_name: registry.redhat.io
 # List of execution environments to download during controller installation:
 ee_images:
    - "{{ ee_registry_name }}/ansible-automation-platform-21/ee-29-rhel8:latest"
-   - "{{ ee_registry_name }}/ee-supported-rhel8:latest"
+   - "{{ ee_registry_name }}/ansible-automation-platform-21/ee-supported-rhel8:latest"
    - "{{ ee_registry_name }}/ansible-automation-platform-21/ee-minimal-rhel8:latest"
 
 # Default EE that uses the registry credential (Default execution environment)


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
this helps @rlopez133 and @craig-br PRs, so now it is almost there for AAP 2.1

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
N/A was missing full EE path
and now also checks for sha256
