### PR TITLE
Updated default AAP installation 2.1.1

### DIFF
--- a/roles/aap_download/defaults/main.yml
+++ b/roles/aap_download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-# December-2021
+# January-2022
 provided_sha_value: 99c12c95e506b1935eee5edbe36870b9fda2c71b825b1e3fafd68153121e9d8f

--- a/roles/aap_download/defaults/main.yml
+++ b/roles/aap_download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # December-2021
-provided_sha_value: ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01
+provided_sha_value: 99c12c95e506b1935eee5edbe36870b9fda2c71b825b1e3fafd68153121e9d8f


### PR DESCRIPTION
##### SUMMARY
- Updated the default AAP installation to version  2.1.1 by updating the default `provided_sha_value` value

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

