### PR TITLE
updated ee_default_image to 21 supported EE

### DIFF
--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -21,6 +21,6 @@ ee_images:
    - "{{ ee_registry_name }}/ansible-automation-platform-21/ee-minimal-rhel8:latest"
 
 # Default EE that uses the registry credential (Default execution environment)
-ee_default_image: "{{ ee_registry_name }}/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.1"
+ee_default_image: "{{ ee_registry_name }}/ansible-automation-platform-21/ee-supported-rhel8:latest"
 # Controller install command
 controller_install_command: "./setup.sh -e gpgcheck=0"


### PR DESCRIPTION
##### SUMMARY
Update the `Default execution environment` to use `registry.redhat.io/ansible-automation-platform-21/ee-supported-rhel8:latest` instead of pre-release EE image.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
- #1431 PR did not update `ee_default_image` default value to the correct EE image version in `roles/control_node/defaults/main.yml` 
- This PR updates the var default value to `"{{ ee_registry_name }}/ee-supported-rhel8:latest`
