### PR TITLE
Add net-tools package for netstat access

### DIFF
--- a/roles/control_node/tasks/15_package_dependencies.yml
+++ b/roles/control_node/tasks/15_package_dependencies.yml
@@ -34,6 +34,7 @@
       - gcc
       - bind-utils
       - jq
+      - net-tools
     state: present
   register: dnf_check
   until: dnf_check is not failed


### PR DESCRIPTION

##### SUMMARY
Fixes #1405 Adds net-tools package in order to be able to use netstat

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

