### PR TITLE
Switch to using "latest" tag for smart_mgmt ee

### DIFF
--- a/roles/control_node/defaults/main.yml
+++ b/roles/control_node/defaults/main.yml
@@ -8,7 +8,7 @@ rhel_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supp
 network_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
 rhel_90_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
 windows_ee: "quay.io/acme_corp/windows_ee:latest"
-smart_mgmt_ee: "quay.io/s4v0/ee-automated-smart-mgmt-29:1.0.4"
+smart_mgmt_ee: "quay.io/s4v0/ee-automated-smart-mgmt-29:latest"
 
 
 # EE registry name used in installer and EE controller credential

--- a/roles/control_node/meta/argument_spec.yml
+++ b/roles/control_node/meta/argument_spec.yml
@@ -30,7 +30,7 @@ argument_specs:
       smart_mgmt_ee:
         type: str
         description: smart_mgmt workshop execution environment
-        default: "quay.io/s4v0/ee-automated-smart-mgmt-29:1.0.4"
+        default: "quay.io/s4v0/ee-automated-smart-mgmt-29:latest"
       username:
         description: The workshop username.
         type: str

--- a/roles/populate_controller/defaults/main.yml
+++ b/roles/populate_controller/defaults/main.yml
@@ -7,4 +7,4 @@ rhel_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supp
 network_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
 rhel_90_ee: "registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0"
 windows_ee: "quay.io/acme_corp/windows_ee:latest"
-smart_mgmt_ee: "quay.io/s4v0/ee-automated-smart-mgmt-29:1.0.4"
+smart_mgmt_ee: "quay.io/s4v0/ee-automated-smart-mgmt-29:latest"


### PR DESCRIPTION
##### SUMMARY
Smart Management workshop deployment currently uses a numbered version tag defined for the smart_mgmt EE deployed by the provisioner automation. Switch to utilization of `latest` tag instead to reduce number of future PRs needed when new smart_mgmt EEs are created.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
`ee-automated-smart-mgmt-29:1.0.4` --> `ee-automated-smart-mgmt-29:latest`
