### PR TITLE
Set SHA256 value to AAP 2.1.1 download

### DIFF
--- a/roles/aap_download/defaults/main.yml
+++ b/roles/aap_download/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # January-2022
-provided_sha_value: 99c12c95e506b1935eee5edbe36870b9fda2c71b825b1e3fafd68153121e9d8f
+provided_sha_value: ac44071ab32248022ee51eed7db2002a772178bfe03807cd08f67dbde58f1941


### PR DESCRIPTION
##### SUMMARY

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
The `provided_sha_value` variable in the `aap_download` role of the `devel` workshop provisioner is currently set to: `99c12c95e506b1935eee5edbe36870b9fda2c71b825b1e3fafd68153121e9d8f` ...which does not match the SHA-256 Checksum of any of the AAP2.x Setup Bundles on the RH AAP download page. Additionally, I (along with several others that I am aware of) have been unable to successfully provision an environment using the currently populated SHA-256 value.  The RH AAP download page provides the following available options...

Ansible Automation Platform 2.0.0 Setup Bundle
SHA-256 Checksum: `f9863ac30b99da8716e45024cf655ae92f60732d9ea5c18074bd5154eabfe48a`

Ansible Automation Platform 2.0.1 Setup Bundle
SHA-256 Checksum: `9e95a63b6fbc65fcf037ad5a7ea939883b57662a3df6b7468f6b91e1003d91b3`

Ansible Automation Platform 2.1.0 Setup Bundle
SHA-256 Checksum: `ea2843fae672274cb1b32447c9a54c627aa5bdf5577d9a6c7f957efe68be8c01`

Ansible Automation Platform 2.1.1 Setup Bundle
SHA-256 Checksum: `ac44071ab32248022ee51eed7db2002a772178bfe03807cd08f67dbde58f1941`

I was able to utilize the 2.1.1 Setup Bundle value of `ac44071ab32248022ee51eed7db2002a772178bfe03807cd08f67dbde58f1941` to successfully deploy AAP 2.1.1.
