### PR TITLE
added smart_mgmt workshop Sat URL to attendance site

### DIFF
--- a/roles/workshop_attendance/templates/index.php.j2
+++ b/roles/workshop_attendance/templates/index.php.j2
@@ -283,10 +283,11 @@ function display_student($student) {
   </table><br>';
 
   {% endif %}
+
   print '<div id="tower_info">
   {% if controllerinstall is defined and controllerinstall %}
-  <div id="section_title">Automation controller</div>
-  To login to the Automation controller WebUI use the following credentials:<br>
+  <div id="section_title">Automation Controller</div>
+  To login to the Automation Controller WebUI use the following credentials:<br>
   <table>
   {% if dns_type != 'none' %}
     <tr>
@@ -310,7 +311,38 @@ function display_student($student) {
     </tr>
   </table>
   {% endif %}
+
+  {% if workshop_type == "smart_mgmt" %}
+  <div id="section_title">Red Hat Satellite </div>
+  To login to the Satellite WebUI use the following credentials:<br>
+  <table>
+  {% if dns_type != 'none' %}
+    <tr>
+  <td>WebUI link:</td>
+  <td><a target=_blank href="https://student' . $student['id'] . '-sat.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}">https://student' . $student['id'] . '-sat.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}</a></td>
+    </tr>
+  {% endif %}
+  {% if dns_type == 'none' %}
+    <tr>
+  <td>UI link:
+  <td><a target=_blank href="https://' . $student['ip'] . '">https://' . $student['ip'] . '</a></td>
+    </tr>
+  {% endif %}
+    <tr>
+      <td>username:</td>
+      <td><code>{% if workshop_type == "windows" %}student' . $student['id'] . '{% else %}admin{% endif %}</code></td>
+    </tr>
+    <tr>
+      <td>password:</td>
+      <td><code>{{admin_password}}</code></td>
+    </tr>
+  </table>
+  {% endif %}
   </div>
+
+
+
+
   {% if workshop_type == 'devops' %} Lab Guide: <a target=_blank href="http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888">http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888</a><br>{% endif %}';
     print '<div id="hub_info">
     {% if automation_hub is defined and automation_hub %}


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Mike Savage is building the Smart Management Workshop, around Satellite Automation. 
The WS itself is now being adapted for RHPDS, I just added a section to the Attendance site's PHP code so that next to the Automation Controller's link also the Satellite URL is displayed (kept all the table formats). 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
