### PR TITLE
Added Satellite URL info if the Workshop is of type smart_mgmt

### DIFF
--- a/roles/workshop_attendance/templates/index.php.j2
+++ b/roles/workshop_attendance/templates/index.php.j2
@@ -311,7 +311,6 @@ function display_student($student) {
     </tr>
   </table>
   {% endif %}
-
   {% if workshop_type == "smart_mgmt" %}
   <div id="section_title">Red Hat Satellite </div>
   To login to the Satellite WebUI use the following credentials:<br>
@@ -339,10 +338,6 @@ function display_student($student) {
   </table>
   {% endif %}
   </div>
-
-
-
-
   {% if workshop_type == 'devops' %} Lab Guide: <a target=_blank href="http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888">http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888</a><br>{% endif %}';
     print '<div id="hub_info">
     {% if automation_hub is defined and automation_hub %}

--- a/roles/workshop_attendance/templates/index.php.j2
+++ b/roles/workshop_attendance/templates/index.php.j2
@@ -286,8 +286,8 @@ function display_student($student) {
 
   print '<div id="tower_info">
   {% if controllerinstall is defined and controllerinstall %}
-  <div id="section_title">Automation Controller</div>
-  To login to the Automation Controller WebUI use the following credentials:<br>
+  <div id="section_title">Automation controller</div>
+  To login to the Automation controller WebUI use the following credentials:<br>
   <table>
   {% if dns_type != 'none' %}
     <tr>

--- a/roles/workshop_attendance/templates/index.php.j2
+++ b/roles/workshop_attendance/templates/index.php.j2
@@ -283,10 +283,11 @@ function display_student($student) {
   </table><br>';
 
   {% endif %}
+
   print '<div id="tower_info">
   {% if controllerinstall is defined and controllerinstall %}
-  <div id="section_title">Automation controller</div>
-  To login to the Automation controller WebUI use the following credentials:<br>
+  <div id="section_title">Automation Controller</div>
+  To login to the Automation Controller WebUI use the following credentials:<br>
   <table>
   {% if dns_type != 'none' %}
     <tr>
@@ -310,7 +311,38 @@ function display_student($student) {
     </tr>
   </table>
   {% endif %}
+
+  {% if workshop_type == "smart_mgmt" %}
+  <div id="section_title">Red Hat Satellite </div>
+  To login to the Satellite WebUI use the following credentials:<br>
+  <table>
+  {% if dns_type != 'none' %}
+    <tr>
+  <td>WebUI link:</td>
+  <td><a target=_blank href="https://student' . $student['id'] . '-sat.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}">https://student' . $student['id'] . '-sat.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}</a></td>
+    </tr>
+  {% endif %}
+  {% if dns_type == 'none' %}
+    <tr>
+  <td>UI link:
+  <td><a target=_blank href="https://' . $student['ip'] . '">https://' . $student['ip'] . '</a></td>
+    </tr>
+  {% endif %}
+    <tr>
+      <td>username:</td>
+      <td><code>{% if workshop_type == "windows" %}student' . $student['id'] . '{% else %}admin{% endif %}</code></td>
+    </tr>
+    <tr>
+      <td>password:</td>
+      <td><code>{{admin_password}}</code></td>
+    </tr>
+  </table>
+  {% endif %}
   </div>
+
+
+
+
   {% if workshop_type == 'devops' %} Lab Guide: <a target=_blank href="http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888">http://student' . $student['id'] . '.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}:8888</a><br>{% endif %}';
     print '<div id="hub_info">
     {% if automation_hub is defined and automation_hub %}


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Mike Savage is working on the Smart Managment Automation Workshop to get it on RHPDS. 
The Smart Management Automation WS is around automating Satellite. 
I have extended the attendance URL's php.j2 template to display the Satellite URL too, if the workshop_type == smart_mgmt. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
