### PR TITLE
Adjustments for change from gp2 to gp3 storage

### DIFF
--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -73,7 +73,10 @@ ec2_info:
     owners: 309956199498
     size: m4.xlarge
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 40
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'RHEL-8*HVM-*Hourly*'
     username: ec2-user
@@ -81,7 +84,10 @@ ec2_info:
     owners: 309956199498
     size: t3.micro
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'RHEL-8*HVM-*Hourly*'
     username: ec2-user
@@ -89,7 +95,10 @@ ec2_info:
     owners: 309956199498
     size: t2.medium
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'RHEL-7.9_HVM*'
     username: ec2-user
@@ -98,7 +107,10 @@ ec2_info:
     owners: 309956199498
     size: t2.medium
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'RHEL-6.8_HVM_GA*'
     username: ec2-user
@@ -107,7 +119,10 @@ ec2_info:
     owners: 125523088429
     size: t2.medium
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'CentOS*7.8*x86_64'
     username: centos
@@ -116,7 +131,10 @@ ec2_info:
     owners: 125523088429
     size: t2.medium
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'CentOS*7.9*x86_64'
     username: centos
@@ -175,7 +193,10 @@ ec2_info:
     owners: 309956199498
     size: t3.micro
     os_type: linux
+    disk_volume_type: gp3
     disk_space: 10
+    disk_iops: 3000
+    disk_throughput: 125
     architecture: x86_64
     filter: 'RHEL-8*HVM-*Hourly*'
     username: ec2-user
@@ -184,6 +205,11 @@ ec2_info:
     filter: Satellite*
     username: ec2-user
     os_type: linux
+    disk_volume_type: gp3
+    disk_space: 500
+    disk_iops: 4000
+    disk_throughput: 375
+    architecture: x86_64
     size: r5a.xlarge
   middleware:
     owners: 309956199498

--- a/roles/manage_ec2_instances/tasks/cluster_instances.yml
+++ b/roles/manage_ec2_instances/tasks/cluster_instances.yml
@@ -30,8 +30,10 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[control_type].disk_volume_type }}"
           volume_size: "{{ ec2_info[control_type].disk_space }}"
+          iops: "{{ ec2_info[control_type].disk_iops }}"
+          throughput: "{{ ec2_info[control_type].disk_throughput }}"
           delete_on_termination: true
   register: control_output
 
@@ -94,7 +96,7 @@
 
     - name: Associate IAM instance profile with control node
       ec2_instance:
-        instance_ids: "{{ item.1.id }}"
+        instance_ids: "{{ item.1.instance_id }}"
         region: "{{ ec2_region }}"
         instance_role: "ControlNode_{{ ec2_name_prefix }}_student{{ item.0 + 1 }}"
         state: running

--- a/roles/manage_ec2_instances/tasks/instances/instances_attendance.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_attendance.yml
@@ -28,4 +28,12 @@
       long_name: "attendance-host.{{ ec2_name_prefix }}.{{ workshop_dns_zone | default('') }}"
       username: "{{ ec2_info['attendance_host']['username'] }}"
       ansible-workshops: "true"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
+          volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
+          delete_on_termination: true
   register: attendance_output

--- a/roles/manage_ec2_instances/tasks/instances/instances_automation_hub.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_automation_hub.yml
@@ -31,7 +31,9 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[control_type].disk_volume_type }}"
           volume_size: "{{ ec2_info[control_type].disk_space }}"
+          iops: "{{ ec2_info[control_type].disk_iops }}"
+          throughput: "{{ ec2_info[control_type].disk_throughput }}"
           delete_on_termination: true
   register: hub_output

--- a/roles/manage_ec2_instances/tasks/instances/instances_centos_6.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_centos_6.yml
@@ -1,15 +1,17 @@
 ---
 - name: Create EC2 instances for node7
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos6].size }}"
     image_id: "{{ node_ami_centos6.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node7": "{{ ec2_name_prefix }}-node7"
     tags:
       Workshop_node7: "{{ ec2_name_prefix }}-node7"
@@ -24,20 +26,24 @@
       Students: "{{ student_total }}"
       short_name: "node7"
       username: "{{ ec2_info[centos6].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos6].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos6].disk_space }}"
+          iops: "{{ ec2_info[centos6].disk_iops }}"
+          throughput: "{{ ec2_info[centos6].disk_throughput }}"
           delete_on_termination: true
 
-- name: grab instance ids to tag them all
+- name: grab instance ids to tag node7
   ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
-      tag:Workshop_node7": "{{ ec2_name_prefix }}-node7"
+      instance-state-name: running
+      "tag:Workshop_node7": "{{ ec2_name_prefix }}-node7"
   register: node7_output
 
 - name: Ensure tags are present for node7
@@ -73,15 +79,17 @@
 
 - name: Create EC2 instances for node8
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos6].size }}"
     image_id: "{{ node_ami_centos6.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node8": "{{ ec2_name_prefix }}-node8"
     tags:
       Workshop_node8: "{{ ec2_name_prefix }}-node8"
@@ -96,13 +104,16 @@
       Students: "{{ student_total }}"
       short_name: "node8"
       username: "{{ ec2_info[centos6].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos6].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos6].disk_space }}"
+          iops: "{{ ec2_info[centos6].disk_iops }}"
+          throughput: "{{ ec2_info[centos6].disk_throughput }}"
           delete_on_termination: true
 
 - name: grab instance ids to tag them all
@@ -145,15 +156,17 @@
 
 - name: Create EC2 instances for node9
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos6].size }}"
     image_id: "{{ node_ami_centos6.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node9": "{{ ec2_name_prefix }}-node9"
     tags:
       Workshop_node9: "{{ ec2_name_prefix }}-node9"
@@ -168,19 +181,23 @@
       Students: "{{ student_total }}"
       short_name: "node9"
       username: "{{ ec2_info[centos6].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos6].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos6].disk_space }}"
+          iops: "{{ ec2_info[centos6].disk_iops }}"
+          throughput: "{{ ec2_info[centos6].disk_throughput }}"
           delete_on_termination: true
 
-- name: grab instance ids to tag them all
+- name: grab instance ids to tag node9
   ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
+      instance-state-name: running
       "tag:Workshop_node9": "{{ ec2_name_prefix }}-node9"
   register: node9_output
 
@@ -200,7 +217,7 @@
 
 - name: Associate IAM instance profile with node9
   amazon.aws.ec2_instance:
-    instance_ids: "{{ item.1.id }}"
+    instance_ids: "{{ item.1.instance_id }}"
     region: "{{ ec2_region }}"
     instance_role: "VPCLockDown_{{ ec2_name_prefix }}_student{{ item.0 + 1 }}"
     state: running

--- a/roles/manage_ec2_instances/tasks/instances/instances_centos_7.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_centos_7.yml
@@ -1,15 +1,17 @@
 ---
 - name: Create EC2 instances for node4
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos7].size }}"
     image_id: "{{ node_ami_centos7.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node4": "{{ ec2_name_prefix }}-node4"
     tags:
       Workshop_node4: "{{ ec2_name_prefix }}-node4"
@@ -24,19 +26,23 @@
       Students: "{{ student_total }}"
       short_name: "node4"
       username: "{{ ec2_info[centos7].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos7].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos7].disk_space }}"
+          iops: "{{ ec2_info[centos7].disk_iops }}"
+          throughput: "{{ ec2_info[centos7].disk_throughput }}"
           delete_on_termination: true
 
-- name: grab instance ids to tag them all
+- name: grab instance ids to tag node4
   ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
+      instance-state-name: running
       "tag:Workshop_node4": "{{ ec2_name_prefix }}-node4"
   register: node4_output
 
@@ -68,21 +74,22 @@
   retries: 12
   delay: 10
   when:
-  when:
     - node4_output.instances|length > 0
     - tower_node_aws_api_access|default(false)|bool
 
 - name: Create EC2 instances for node5
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos7].size }}"
     image_id: "{{ node_ami_centos7.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node5": "{{ ec2_name_prefix }}-node5"
     tags:
       Workshop_node5: "{{ ec2_name_prefix }}-node5"
@@ -97,19 +104,23 @@
       Students: "{{ student_total }}"
       short_name: "node5"
       username: "{{ ec2_info[centos7].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos7].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos7].disk_space }}"
+          iops: "{{ ec2_info[centos7].disk_iops }}"
+          throughput: "{{ ec2_info[centos7].disk_throughput }}"
           delete_on_termination: true
 
 - name: grab instance ids to tag them all
   ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
+      instance-state-name: running
       "tag:Workshop_node5": "{{ ec2_name_prefix }}-node5"
   register: node5_output
 
@@ -146,15 +157,17 @@
 
 - name: Create EC2 instances for node6
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[centos7].size }}"
     image_id: "{{ node_ami_centos7.image_id }}"
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
-    network:
-      assign_public_ip: true
+    state: running
     filters:
+      instance-state-name: running
       "tag:Workshop_node6": "{{ ec2_name_prefix }}-node6"
     tags:
       Workshop_node6: "{{ ec2_name_prefix }}-node6"
@@ -169,19 +182,23 @@
       Students: "{{ student_total }}"
       short_name: "node6"
       username: "{{ ec2_info[centos7].username }}"
+      ansible-workshops: "true"
     wait: "{{ ec2_wait }}"
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[centos7].disk_volume_type }}"
           volume_size: "{{ ec2_info[centos7].disk_space }}"
+          iops: "{{ ec2_info[centos7].disk_iops }}"
+          throughput: "{{ ec2_info[centos7].disk_throughput }}"
           delete_on_termination: true
 
-- name: grab node6 instance ids to tag them all
+- name: grab instance ids to tag node6
   ec2_instance_info:
     region: "{{ ec2_region }}"
     filters:
+      instance-state-name: running
       "tag:Workshop_node6": "{{ ec2_name_prefix }}-node6"
   register: node6_output
 

--- a/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_rhel.yml
@@ -1,6 +1,8 @@
 ---
 - name: Create EC2 instances for node1
   amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
     security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info[rhel].size }}"
@@ -8,8 +10,6 @@
     region: "{{ ec2_region }}"
     exact_count: "{{ student_total }}"
     state: running
-    network:
-      assign_public_ip: true
     filters:
       instance-state-name: running
       "tag:Workshop_node1": "{{ ec2_name_prefix }}-node1"
@@ -32,8 +32,10 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
           volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
           delete_on_termination: true
   register: sean_test
 
@@ -112,8 +114,10 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
           volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
           delete_on_termination: true
 
 - name: grab instance ids to tag node2
@@ -188,8 +192,10 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
           volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
           delete_on_termination: true
 
 - name: grab instance ids to tag node3
@@ -264,8 +270,10 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
           volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
           delete_on_termination: true
   when: create_cluster|bool
 
@@ -322,9 +330,12 @@
     vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"
     volumes:
       - device_name: /dev/sda1
-        volume_type: gp2
-        volume_size: "{{ ec2_info[rhel].disk_space }}"
-        delete_on_termination: true
+        ebs:
+          volume_type: "{{ ec2_info[rhel].disk_volume_type }}"
+          volume_size: "{{ ec2_info[rhel].disk_space }}"
+          iops: "{{ ec2_info[rhel].disk_iops }}"
+          throughput: "{{ ec2_info[rhel].disk_throughput }}"
+          delete_on_termination: true
   when: create_cluster|bool
 
 - name: grab instance ids to tag isonode

--- a/roles/manage_ec2_instances/tasks/instances/instances_smart_mgmt.yml
+++ b/roles/manage_ec2_instances/tasks/instances/instances_smart_mgmt.yml
@@ -14,17 +14,19 @@
   when: not ebs_optimized_instance_selected.changed
 
 - name: provision satellite server
-  ec2:
-    assign_public_ip: true
+  amazon.aws.ec2_instance:
+    network:
+      assign_public_ip: true
     key_name: "{{ ec2_name_prefix }}-key"
-    group: "{{ ec2_security_group }}"
+    security_group: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_info['satellite'].size }}"
-    image: "{{ sat_ami.image_id }}"
+    image_id: "{{ sat_ami.image_id }}"
     region: "{{ ec2_region }}"
-    ebs_optimized: "{{ ebs_optimized_capable | default(false) }}"
     exact_count: "{{ student_total }}"
-    count_tag:
-      Workshop_satellite: "{{ ec2_name_prefix }}-satellite"
+    state: running
+    filters:
+      instance-state-name: running
+      "tag:Workshop_satellite": "{{ ec2_name_prefix }}-satellite"
     tags:
       Workshop_satellite: "{{ ec2_name_prefix }}-satellite"
       Workshop: "{{ ec2_name_prefix }}"
@@ -34,7 +36,7 @@
       AWS_USERNAME: "{{ aws_user }}"
       owner: "{{ aws_user }}"
       Info: "AWS_USERNAME that provisioned this-> {{ aws_user }}"
-      Linklight: "This was provisioned through the linklight provisioner"
+      Ansible_Workshops: "This was provisioned through the ansible workshops provisioner"
       Students: "{{ student_total }}"
       short_name: "satellite"
       username: "{{ ec2_info[rhel].username }}"
@@ -44,15 +46,25 @@
     volumes:
       - device_name: /dev/sda1
         ebs:
-          volume_type: gp2
-          volume_size: 500
+          volume_type: "{{ ec2_info['satellite'].disk_volume_type }}"
+          volume_size: "{{ ec2_info['satellite'].disk_space }}"
+          iops: "{{ ec2_info['satellite'].disk_iops }}"
+          throughput: "{{ ec2_info['satellite'].disk_throughput }}"
           delete_on_termination: true
+    ebs_optimized: "{{ ebs_optimized_capable | default(false) }}"
+
+- name: grab instance ids to tag each satellite
+  ec2_instance_info:
+    region: "{{ ec2_region }}"
+    filters:
+      instance-state-name: running
+      "tag:Workshop_satellite": "{{ ec2_name_prefix }}-satellite"
   register: satellite_output
 
 - name: Ensure tags are present for satellite
   ec2_tag:
     region: "{{ ec2_region }}"
-    resource: "{{ item.1.id }}"
+    resource: "{{ item.1.instance_id }}"
     state: present
     tags:
       Name: "{{ ec2_name_prefix }}-student{{ item.0 + 1 }}-satellite"
@@ -61,7 +73,7 @@
       launch_time: "{{ item.1.launch_time }}"
   with_indexed_items:
     - "{{ satellite_output.instances }}"
-  when: satellite_output.instance_ids is not none
+  when: satellite_output.instances|length > 0
 
 ## re-use RHEL workshop code
 - name: provision aws rhel instances


### PR DESCRIPTION
##### SUMMARY
In December 2020, AWS introduced a new Amazon EBS General Purpose SSD volume type, gp3. AWS designed gp3 to provide predictable 3,000 IOPS baseline performance and 125 MiB/s, regardless of volume size. With gp3 volumes, you can provision IOPS and throughput independently, without increasing storage size, at costs up to 20% lower per GB compared to gp2 volumes.  This PR introduces the first stage of changes providing the capability to parameterize storage properties for workshop instances, paving the way for a change to defaulting to gp3 storage for Ansible workshop deployments, providing the same performance as previous gp2 storage, but at a lower cost.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

