### PR TITLE
Add retries to api settings

### DIFF
--- a/roles/cp_fix_mgmt/tasks/main.yml
+++ b/roles/cp_fix_mgmt/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: ensure API settings
   command: mgmt_cli -r true set api-settings accepted-api-calls-from "All IP addresses" --domain 'System Data'
+  register: set_api
+  until: set_api is not failed
+  retries: 5
+  delay: 10
 
 - name: api restart
   command: api restart


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add retries to task ensure API settings. There doesn't appear to be an obvious timing relationship, and it seems to always be the first instance tried. Fixes #1544

Note: linters is passing before pushing.
(ansible) dpullman@dpullman-macos ansible-workshops % tox -e linters
linters installed: pathspec==0.9.0,PyYAML==6.0,yamllint==1.26.3
linters run-test-pre: PYTHONHASHSEED='1489372215'
linters run-test: commands[0] | yamllint -s .
_______________________________________________ summary _______________________________________________
  linters: commands succeeded
  congratulations :)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
