### PR TITLE
Inspect var instead of fail

### DIFF
--- a/roles/control_node/tasks/30_controller.yml
+++ b/roles/control_node/tasks/30_controller.yml
@@ -73,11 +73,11 @@
         content: '{{ base64_manifest | b64decode }}'
       delegate_to: localhost
       become: false
-  rescue:
+      when: base64_manifest is defined
     - name: unable to load base64_manifest
       debug:
         msg: 'No base64_manifest variable found, trying to open manifest.zip'
-  always:
+      when: base64_manifest is undefined
     - name: Load manifest into variable
       local_action:
         module: slurp


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change task load_license_block to inspect for defined value instead of failing to read value. Fixes #1553.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Note: passes tox linters for file updated, but other recent changes from devel are failing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
