### PR TITLE
set ansible language server as default for .*yml

### DIFF
--- a/roles/code_server/templates/settings.json
+++ b/roles/code_server/templates/settings.json
@@ -10,5 +10,8 @@
     "git.confirmSync": false,
     "workbench.colorTheme": "Visual Studio Dark",
     "ansible.ansibleLint.enabled": false,
-    "ansible.ansible.useFullyQualifiedCollectionNames": true
+    "ansible.ansible.useFullyQualifiedCollectionNames": true,
+    "files.associations": {
+        "*.yml": "ansible"
+    }
 }


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sets ansible as default language server for `.yml` file extension
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
