### PR TITLE
add retry on failure with delays

### DIFF
--- a/roles/aap_download/tasks/10_download.yml
+++ b/roles/aap_download/tasks/10_download.yml
@@ -13,6 +13,9 @@
       client_id: "rhsm-api"
       refresh_token: "{{ offline_token }}"
   register: temp_token
+  until: temp_token is not failed
+  retries: 15
+  delay: 20
 
 - name: Download aap.tar.gz
   delegate_to: localhost
@@ -23,3 +26,7 @@
       Authorization: "Bearer {{ temp_token.json.access_token }}"
     dest: "{{ playbook_dir }}/aap.tar.gz"
     checksum: "sha256: {{ provided_sha_value }}"
+  register: download_aap_tarball
+  until: download_aap_tarball is not failed
+  retries: 15
+  delay: 20


### PR DESCRIPTION
##### SUMMARY
Occasional failures occur during offline token post to sso.redhat.com or downloading AAP install bundle from api.access.redhat.com.  Adding a retry on failure with delay could potentially resolve issues where spurious network transport errors/anomalies occur.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
The following is a test of the change where I manipulated the hosts file in the background to simulate post/download failures...

```TASK [download AAP] *****************************************************************************************************************

TASK [../roles/aap_download : check if aap.tar.gz exists] ***************************************************************************
ok: [localhost]

TASK [../roles/aap_download : download aap.tar.gz from access.redhat.com] ***********************************************************
included: /home/msavage/github/ansible/workshops/roles/aap_download/tasks/10_download.yml for localhost

TASK [../roles/aap_download : Generating an access token] ***************************************************************************
FAILED - RETRYING: Generating an access token (15 retries left).
ok: [localhost]

TASK [../roles/aap_download : Download aap.tar.gz] **********************************************************************************
FAILED - RETRYING: Download aap.tar.gz (15 retries left).
changed: [localhost -> localhost]

TASK [../roles/aap_download : check if aap.tar.gz again (post download)] ************************************************************
ok: [localhost]

TASK [../roles/aap_download : Verify sha256sum of aap.tar.gz] ***********************************************************************
skipping: [localhost]

PLAY [Create lab instances in AWS] *****

```
