### PR TITLE
Adding a mountpoint for all the workshop_types in navigator.yml

### DIFF
--- a/roles/control_node/templates/ansible-navigator.yml.j2
+++ b/roles/control_node/templates/ansible-navigator.yml.j2
@@ -12,3 +12,6 @@ ansible-navigator:
     volume-mounts:
     - src: "/etc/ansible/"
       dest: "/etc/ansible/"
+    - src: {{ '/tmp/' + workshop_type + '/'}}
+      dest: {{ '/tmp/' + workshop_type + '/' }}
+    


### PR DESCRIPTION
Add a mountpoint under /tmp/ as <workshop_type>, to be used for any files that needs to be used by workshop playbooks

