### PR TITLE
Remove connection vars from inventory template

### DIFF
--- a/roles/manage_ec2_instances/templates/student_inventory/instances_rhel.j2
+++ b/roles/manage_ec2_instances/templates/student_inventory/instances_rhel.j2
@@ -1,10 +1,3 @@
-[all:vars]
-ansible_user=student{{ item }}
-ansible_ssh_pass={{ admin_password }}
-{% if ssh_port is defined %}
-ansible_port={{ ssh_port }}
-{% endif %}
-
 [web]
 {% for vm in node1_node_facts.instances %}
 {% if 'student' + item == vm.tags.Student %}


### PR DESCRIPTION
##### SUMMARY
This removes the connection vars from the inventory file that is loaded into controller later on.

The vars are legacy anyway and seem to prevent SSH connection using the proper Credentials from working now. 

See issue #1585

**This only fixes the RHEL Workshop!**

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
