### PR TITLE
Security workshop fails on async_status

### DIFF
--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -256,3 +256,6 @@ ec2_info:
     filter: 'RHEL-8*HVM-*Hourly*'
     username: ec2-user
 debug_teardown: false
+
+# Issue #1594
+ansible_async_dir: "/tmp/.ansible_async"

--- a/roles/workshop_check_setup/defaults/main.yml
+++ b/roles/workshop_check_setup/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 output_dir: "{{ playbook_dir }}/{{ ec2_name_prefix }}"
+
+# Issue #1594
+ansible_async_dir: "/tmp/.ansible_async"


### PR DESCRIPTION
##### SUMMARY
Fixes #1594
- Add `ansible_async_dir: "/tmp/.ansible_async"` to `manage_ec2` and `workshop_check_setup` roles.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
Security workshop failed to deploy using an execution environment due to `async_status` searching for  `ansible_job_id` in the incorrect directory. 

**Workaround**
https://access.redhat.com/solutions/6698561