### PR TITLE
Ignore IAM-related errors during workshop teardown

### DIFF
--- a/roles/manage_ec2_instances/tasks/teardown.yml
+++ b/roles/manage_ec2_instances/tasks/teardown.yml
@@ -411,6 +411,7 @@
       loop: "{{ range(1, student_total + 1)|list }}"
 
   when: tower_node_aws_api_access|default(false)|bool
+  ignore_errors: true
 
 - name: Delete AWS snapshots (workshop_type SMART MANAGEMENT)
   block:


### PR DESCRIPTION
##### SUMMARY
If the `smart_mgmt` workshop deploy is interrupted before the IAM-related policies and roles are created, subsequent teardown runs will error/fail because when the IAM teardown tasks are executed,  these objects do not exist. A simple ignore_error: true bypasses this issue. This is a quick-fix to implement on a temporary basis while a method of performing IAM role and policy removal via deletion from generated list is composed and tested.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

