### PR TITLE
fixed wrong translation for RHEL exercise 1.3 ja

### DIFF
--- a/exercises/ansible_rhel/1.3-playbook/README.ja.md
+++ b/exercises/ansible_rhel/1.3-playbook/README.ja.md
@@ -309,7 +309,7 @@ ansible                    : ok=3    changed=0    unreachable=0    failed=0    s
 ```
 
 `ansible-navigator run apache.yml` Playbook を 2
-回ずつ実行し、出力を比較します。出力「CHANGED」には `0` ではなく `1`
+回ずつ実行し、出力を比較します。出力「CHANGED」には `1` ではなく 0`
 が表示され、色が黄色から緑色に変更されます。これにより、Ansible Playbook
 の実行時に変更が生じると、その変更を簡単に配置できるようになります。
 


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixed wrong translation for RHEL exercise 1.3 ja.

The original is below
>The output “CHANGED” now shows 0 instead of 1 and the color changed from yellow to green. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
