### PR TITLE
fixing template motd for instruqt/workshops

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,7 +17,8 @@
 - hostname:
     name: "{{ short_name|default('automation-controller') }}.example.com"
 
-- template:
+- name: template out motd
+  template:
     src: motd.j2
     dest: /etc/motd
 

--- a/roles/common/templates/motd.j2
+++ b/roles/common/templates/motd.j2
@@ -1,4 +1,4 @@
-#### This workbench is for {{ student }} ####
+#### This workbench is for {{ student | default('student') }} ####
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @@@@@@@@@@@     ############     m@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @@@@@@@@@@     ################   m@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -12,8 +12,8 @@
 @@@@@@@@@@@     ####################     m@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @@@@@@@@@@@@@@@@     #############     m@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-#### This workbench is for {{ student }} ####
-- Public FQDN: {{ student }}.{{ ec2_name_prefix|default("ansible") }}.{{ workshop_dns_zone|default("demo") }}
+#### This workbench is for {{ student | default('student') }} ####
+- Public FQDN: {{ student | default('student') }}.{{ ec2_name_prefix|default("ansible") }}.{{ workshop_dns_zone|default("demo") }}
 — Local FQDN: {{ ansible_fqdn }}
 — Distro: {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_distribution_release }}
 — Virtual: {{ 'YES' if ansible_virtualization_role == 'guest' else 'NO' }}


### PR DESCRIPTION

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
fixing windows workshop for @cloin, when the provisioner runs there may not be a student... so default to student

in the case of the gitlab/gitea there is no "student" var


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
n/a
