### PR TITLE
Fixes to the pah role for instruqt image creation

### DIFF
--- a/roles/private_automation_hub/defaults/main.yml
+++ b/roles/private_automation_hub/defaults/main.yml
@@ -2,3 +2,4 @@
 aap_dir: "/home/{{ username }}/aap_install"
 output_dir: "{{ playbook_dir }}/{{ ec2_name_prefix }}"
 state: present
+teardown: false

--- a/roles/private_automation_hub/templates/hub_install.j2
+++ b/roles/private_automation_hub/templates/hub_install.j2
@@ -1,7 +1,11 @@
 [automationcontroller]
 
 [automationhub]
+{% if workshop_type is defined %}
 {{ ansible_host }} ansible_connection=local
+{% else %}
+automationhub ansible_connection=local
+{% endif %}
 
 [database]
 


### PR DESCRIPTION
adds a default teardown variable
adds a template condition when workshop_type is not defined