### PR TITLE
Bblasco provisioner doc fix

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,6 +37,7 @@ Here are the setup directions you have to perform one time for the [workshop pro
 
 | package  | `dnf`   | `pip`  |
 |---|---|---|
+| [git](https://git.kernel.org/pub/scm/git/git.git) | `git` | N/A |
 | [ansible-core](https://docs.ansible.com/core.html) 2.11 or newer | `ansible-core` | `ansible-core` |
 | [boto3](https://aws.amazon.com/sdk-for-python/) - required for `amazon.aws` collection | `python3-boto3` | `boto3` |
 | [netaddr](https://netaddr.readthedocs.io/en/latest/)| `python3-netaddr` | `netaddr` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -73,7 +73,7 @@ The windows workshops will also require pywinrm and requests-credssp
 
 | package  | `dnf`   | `pip`  |
 |---|---|---|
-| [pywinrm](https://github.com/diyan/pywinrm)| `python3-pywinrm` | `pywinrm`
+| [pywinrm](https://github.com/diyan/pywinrm)| `python3-winrm` | `pywinrm`
 | [requests-credssp](https://pypi.org/project/requests-credssp/)| `python3-requests-credssp` | `requests-credssp` |
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,7 +102,7 @@ If you haven't done so already make sure you have the repo cloned to the machine
 ## 6. Run the requirements.yml file to ensure all the Ansible collection prerequisites are met.
 ￼
 ￼```
-￼ansible-galaxy collection install -r requirements.yml
+￼ansible-galaxy collection install -r collections/requirements.yml
 ￼```
 
 ## 7.  Subscribe to AWS marketplace images

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -285,6 +285,8 @@ ansible-playbook teardown_lab.yml -e @extra_vars.yml
 ansible-playbook teardown_lab.yml -e @extra_vars.yml -e debug_teardown=true
 ```
 
+Note: Replace `ansible-playbook` with `ansible-navigator run` if using `ansible-navigator`.
+
 ## Demos
 
 There is a variable you can pass in within your extra_vars named `demo`.  When this keyword is defined it will install the specified demo from the Github repository [https://github.com/ansible/product-demos](https://github.com/ansible/product-demos).h


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates to provisioner documentation as per issue #1704 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION

One time setup updates and provisioner instruction updates after running through them myself on a Fedora 35 host. I want these instructions to be usable by RH partners so they can deploy their own workshops without any doubts as to how to run them.