### PR TITLE
Change install path for role

### DIFF
--- a/roles/workshop_check_setup/tasks/security.yml
+++ b/roles/workshop_check_setup/tasks/security.yml
@@ -6,7 +6,7 @@
     msg: "windows_password must be set for security automation workshop"
 
 - name: required roles
-  shell: "ansible-galaxy install {{item}} -f --force-with-deps -p ./roles/"
+  shell: "ansible-galaxy install {{item}} -f --force-with-deps -p ./workshop_specific/roles/"
   async: 600
   poll: 0
   loop:


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the path to install the workshop specific roles from galaxy to ./workshop_specific/roles rather than ./roles. This is because the tasks to use the roles have been moved to workshop_specific and can't find them.

Fixes #1706
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The recent change to put specific roles in a subdirectory broke the install of geerlingguy.repo-epel and two other security specific role installs.

This is similar to the F5 issue opened recently #1683. I think this is the correct way to fix this issue, but please let me know if it should be done the other way.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
