### PR TITLE
Add playbooks from security exercises. Fix QRadar rule to be consistent...

### DIFF
--- a/exercises/ansible_security/1.4-qradar/README.fr.md
+++ b/exercises/ansible_security/1.4-qradar/README.fr.md
@@ -150,7 +150,7 @@ Ensuite, nous apportons les tâches réelles. L'API REST de QRadar est conçue d
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
 ```
 
 Ce module renvoie de nombreuses informations, parmi lesquelles l'ID dont nous avons besoin pour désactiver le rôle. Enregistrons les informations retournées dans une variable à l'aide du mot-clé `register`. Il est directement utilisé avec le module lui-même. Cela nous permet d'utiliser le contenu de la variable dans la tâche suivante.
@@ -165,7 +165,7 @@ Ce module renvoie de nombreuses informations, parmi lesquelles l'ID dont nous av
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
       register: rule_info
 ```
 

--- a/exercises/ansible_security/1.4-qradar/README.ja.md
+++ b/exercises/ansible_security/1.4-qradar/README.ja.md
@@ -165,7 +165,7 @@ project](https://github.com/ansible-security/ibm_qradar). にあります。
 
 > **注記**
 >
-> Ansible Automation Platform には、独自のカスタム実行環境を作成するために使用できる `ansible-builder` が含まれています。`ansible-builder` の詳細は、[blog post](https://www.ansible.com/blog/introduction-to-ansible-builder). を参照してください。   
+> Ansible Automation Platform には、独自のカスタム実行環境を作成するために使用できる `ansible-builder` が含まれています。`ansible-builder` の詳細は、[blog post](https://www.ansible.com/blog/introduction-to-ansible-builder). を参照してください。
 
 ## ステップ 4.4 - 最初の Playbook の例
 
@@ -203,7 +203,7 @@ VS Code のオンラインエディターで、ユーザーのホームディレ
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
 ```
 
 このモジュールは多くの情報を返しますが、その中には実際にロールを無効にするために必要な ID も含まれています。ここでは、`register`
@@ -219,7 +219,7 @@ VS Code のオンラインエディターで、ユーザーのホームディレ
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
       register: rule_info
 ```
 

--- a/exercises/ansible_security/1.4-qradar/README.md
+++ b/exercises/ansible_security/1.4-qradar/README.md
@@ -18,7 +18,7 @@ Have a first look at the SIEM, and verify that it is actually working. Point you
 
 > **Note**
 >
-> In a production environment, accepting a insecure certificate would not be an option. Since the lab setup is only short lived and solely serves a demo purpose we accept the risk in this case.  
+> In a production environment, accepting a insecure certificate would not be an option. Since the lab setup is only short lived and solely serves a demo purpose we accept the risk in this case.
 
 > **Note**
 >
@@ -83,7 +83,7 @@ Automation execution environments can be customized to include the collections y
 
 > **Note**
 >
-> Ansible Automation Platform includes `ansible-builder` which you can use to create your own custom execution environments. For more information on `ansible-builder` please have a look at our [blog post](https://www.ansible.com/blog/introduction-to-ansible-builder).   
+> Ansible Automation Platform includes `ansible-builder` which you can use to create your own custom execution environments. For more information on `ansible-builder` please have a look at our [blog post](https://www.ansible.com/blog/introduction-to-ansible-builder).
 
 ## 1.4.4 First example playbook
 
@@ -119,7 +119,7 @@ Next we bring in the actual tasks. The REST API of QRadar is designed in a way t
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
 ```
 
 This module returns a lot of information, among those the ID we need to actually disable the role. Let's register the returned information into a variable with the help of the `register` keyword. It is directly used with the module itself. This enables us to use the content of the variable in the next task.
@@ -134,7 +134,7 @@ This module returns a lot of information, among those the ID we need to actually
   tasks:
     - name: get info about qradar rule
       qradar_rule_info:
-        name: "DDoS Attack Detected"
+        name: "Potential DDoS Against Single Host (TCP)"
       register: rule_info
 ```
 

--- a/exercises/ansible_security/1.4-qradar/playbooks/change_qradar_rule.yml
+++ b/exercises/ansible_security/1.4-qradar/playbooks/change_qradar_rule.yml
@@ -1,0 +1,16 @@
+---
+- name: Change QRadar rule state
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: get info about qradar rule
+      qradar_rule_info:
+        name: "Potential DDoS Against Single Host (TCP)"
+      register: rule_info
+
+    - name: disable rule by id
+      qradar_rule:
+        state: disabled
+        id: "{{ rule_info.rules[0]['id'] }}"

--- a/exercises/ansible_security/1.4-qradar/playbooks/find_qradar_rule.yml
+++ b/exercises/ansible_security/1.4-qradar/playbooks/find_qradar_rule.yml
@@ -1,0 +1,15 @@
+---
+- name: Find QRadar rule state
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: get info about qradar rule
+      qradar_rule_info:
+        name: "Potential DDoS Against Single Host (TCP)"
+      register: rule_info
+
+    - name: output returned rule_info
+      debug:
+        var: rule_info

--- a/exercises/ansible_security/2.1-enrich/README.md
+++ b/exercises/ansible_security/2.1-enrich/README.md
@@ -98,7 +98,7 @@ Doing this manually requires a lot of work on multiple machines, which again tak
 
 > **Note**
 >
-> Why don't we add those logs to QRadar permanently? The reason is that many log systems are licensed/paid by the amount of logs they consume, making it expansive pushing non-necessary logs in there. Also, if too many logs are in there it becomes harder to analyse the data properly and in a timely manner.
+> Why don't we add those logs to QRadar permanently? The reason is that many log systems are licensed/paid by the amount of logs they consume, making it expensive pushing non-necessary logs in there. Also, if too many logs are in there it becomes harder to analyse the data properly and in a timely manner.
 
 So let's write such a playbook which first configures the log sources - Snort and Check Point - to send the logs to QRadar, and afterwards add those log sources to QRadar so that it is aware of them.
 
@@ -313,7 +313,7 @@ Log onto the QRadar web UI. Click on **Log Activity**. As you will see, there ar
 
 > **IBM QRadar Credentials**
 >
-> Username: `admin`  
+> Username: `admin`
 > Password: `Ansible1!`
 
 > **Note**
@@ -340,7 +340,7 @@ Let's verify that QRadar also properly shows the log source. In the QRadar UI, c
 
 ![QRadar hamburger](images/2-qradar-hamburger.png#centreme)
 
-In there, click on **Log Sources**.  
+In there, click on **Log Sources**.
 
 ![QRadar log sources](images/2-qradar-log-sources.png#centreme)
 

--- a/exercises/ansible_security/2.1-enrich/playbooks/enrich_log_sources.yml
+++ b/exercises/ansible_security/2.1-enrich/playbooks/enrich_log_sources.yml
@@ -1,0 +1,62 @@
+---
+- name: Configure snort for external logging
+  hosts: snort
+  become: true
+  vars:
+    ids_provider: "snort"
+    ids_config_provider: "snort"
+    ids_config_remote_log: true
+    ids_config_remote_log_destination: "{{ hostvars['qradar']['private_ip'] }}"
+    ids_config_remote_log_procotol: udp
+    ids_install_normalize_logs: false
+
+  tasks:
+    - name: import ids_config role
+      include_role:
+        name: "ansible_security.ids_config"
+
+- name: Add Snort log source to QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Add snort remote logging to QRadar
+      qradar_log_source_management:
+        name: "Snort rsyslog source - {{ hostvars['snort']['private_ip'] }}"
+        type_name: "Snort Open Source IDS"
+        state: present
+        description: "Snort rsyslog source"
+        identifier: "{{ hostvars['snort']['ansible_fqdn'] }}"
+
+- name: Configure Check Point to send logs to QRadar
+  hosts: checkpoint
+
+  tasks:
+    - include_role:
+        name: ansible_security.log_manager
+        tasks_from: forward_logs_to_syslog
+      vars:
+        syslog_server: "{{ hostvars['qradar']['private_ip'] }}"
+        # retrieve from checkpoint GUI, e.g. gw-abc123
+        checkpoint_server_name: "YOURSERVERNAME"
+        firewall_provider: checkpoint
+
+- name: Add Check Point log source to QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Add Check Point remote logging to QRadar
+      qradar_log_source_management:
+        name: "Check Point source - {{ hostvars['checkpoint']['private_ip'] }}"
+        type_name: "Check Point FireWall-1"
+        state: present
+        description: "Check Point log source"
+        identifier: "{{ hostvars['checkpoint']['private_ip'] }}"
+
+    - name: deploy the new log sources
+      qradar_deploy:
+        type: INCREMENTAL
+      failed_when: false

--- a/exercises/ansible_security/2.1-enrich/playbooks/enrich_snort_rule.yml
+++ b/exercises/ansible_security/2.1-enrich/playbooks/enrich_snort_rule.yml
@@ -1,0 +1,21 @@
+---
+- name: Add Snort rule
+  hosts: snort
+  become: true
+
+  vars:
+    ids_provider: snort
+    protocol: tcp
+    source_port: any
+    source_ip: any
+    dest_port: any
+    dest_ip: any
+
+  tasks:
+    - name: Add snort web attack rule
+      include_role:
+        name: "ansible_security.ids_rule"
+      vars:
+        ids_rule: 'alert {{protocol}} {{source_ip}} {{source_port}} -> {{dest_ip}} {{dest_port}}  (msg:"Attempted Web Attack"; uricontent:"/web_attack_simulation"; classtype:web-application-attack; sid:99000020; priority:1; rev:1;)'
+        ids_rules_file: '/etc/snort/rules/local.rules'
+        ids_rule_state: present

--- a/exercises/ansible_security/2.1-enrich/playbooks/rollback.yml
+++ b/exercises/ansible_security/2.1-enrich/playbooks/rollback.yml
@@ -1,0 +1,62 @@
+---
+- name: Disable external logging in Snort
+  hosts: snort
+  become: true
+  vars:
+    ids_provider: "snort"
+    ids_config_provider: "snort"
+    ids_config_remote_log: false
+    ids_config_remote_log_destination: "{{ hostvars['qradar']['private_ip'] }}"
+    ids_config_remote_log_procotol: udp
+    ids_install_normalize_logs: false
+
+  tasks:
+    - name: import ids_config role
+      include_role:
+        name: "ansible_security.ids_config"
+
+- name: Remove Snort log source from QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Remove snort remote logging from QRadar
+      qradar_log_source_management:
+        name: "Snort rsyslog source - {{ hostvars['snort']['private_ip'] }}"
+        type_name: "Snort Open Source IDS"
+        state: absent
+        description: "Snort rsyslog source"
+        identifier: "{{ hostvars['snort']['ansible_fqdn'] }}"
+
+- name: Configure Check Point to not send logs to QRadar
+  hosts: checkpoint
+
+  tasks:
+    - include_role:
+        name: ansible_security.log_manager
+        tasks_from: unforward_logs_to_syslog
+      vars:
+        syslog_server: "{{ hostvars['qradar']['private_ip'] }}"
+        # retrieve from checkpoint GUI, e.g. gw-abc123
+        checkpoint_server_name: "YOURSERVERNAME"
+        firewall_provider: checkpoint
+
+- name: Remove Check Point log source from QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Remove Check Point remote logging from QRadar
+      qradar_log_source_management:
+        name: "Check Point source - {{ hostvars['checkpoint']['private_ip'] }}"
+        type_name: "Check Point NGFW"
+        state: absent
+        description: "Check Point log source"
+        identifier: "{{ hostvars['checkpoint']['private_ip'] }}"
+
+    - name: deploy the log source changes
+      qradar_deploy:
+        type: INCREMENTAL
+      failed_when: false

--- a/exercises/ansible_security/2.3-incident/playbooks/incident_blacklist.yml
+++ b/exercises/ansible_security/2.3-incident/playbooks/incident_blacklist.yml
@@ -1,0 +1,35 @@
+---
+- name: Blacklist attacker
+  hosts: checkpoint
+
+  vars:
+    source_ip: "{{ hostvars['attacker']['private_ip2'] }}"
+    destination_ip: "{{ hostvars['snort']['private_ip2'] }}"
+
+  tasks:
+    - name: Create source IP host object
+      checkpoint_host:
+        name: "asa-{{ source_ip }}"
+        ip_address: "{{ source_ip }}"
+
+    - name: Create destination IP host object
+      checkpoint_host:
+        name: "asa-{{ destination_ip }}"
+        ip_address: "{{ destination_ip }}"
+
+    - name: Create access rule to deny access from source to destination
+      checkpoint_access_rule:
+        auto_install_policy: yes
+        auto_publish_session: yes
+        layer: Network
+        position: top
+        name: "asa-accept-{{ source_ip }}-to-{{ destination_ip }}"
+        source: "asa-{{ source_ip }}"
+        destination: "asa-{{ destination_ip }}"
+        action: drop
+
+    - name: Install policy
+      cp_mgmt_install_policy:
+        policy_package: standard
+        install_on_all_cluster_members_or_fail: yes
+      failed_when: false

--- a/exercises/ansible_security/2.3-incident/playbooks/incident_snort_log.yml
+++ b/exercises/ansible_security/2.3-incident/playbooks/incident_snort_log.yml
@@ -1,0 +1,35 @@
+---
+- name: Configure snort for external logging
+  hosts: snort
+  become: true
+  vars:
+    ids_provider: "snort"
+    ids_config_provider: "snort"
+    ids_config_remote_log: true
+    ids_config_remote_log_destination: "{{ hostvars['qradar']['private_ip'] }}"
+    ids_config_remote_log_procotol: udp
+    ids_install_normalize_logs: false
+
+  tasks:
+    - name: import ids_config role
+      include_role:
+        name: "ansible_security.ids_config"
+
+- name: Add Snort log source to QRadar
+  hosts: qradar
+  collections:
+    - ibm.qradar
+
+  tasks:
+    - name: Add snort remote logging to QRadar
+      qradar_log_source_management:
+        name: "Snort rsyslog source - {{ hostvars['snort']['private_ip'] }}"
+        type_name: "Snort Open Source IDS"
+        state: present
+        description: "Snort rsyslog source"
+        identifier: "{{ hostvars['snort']['ansible_fqdn'] }}"
+
+    - name: deploy the new log sources
+      qradar_deploy:
+        type: INCREMENTAL
+      failed_when: false

--- a/exercises/ansible_security/2.3-incident/playbooks/incident_snort_rule.yml
+++ b/exercises/ansible_security/2.3-incident/playbooks/incident_snort_rule.yml
@@ -1,0 +1,21 @@
+---
+- name: Add ids signature for sql injection simulation
+  hosts: ids
+  become: true
+
+  vars:
+    ids_provider: snort
+    protocol: tcp
+    source_port: any
+    source_ip: any
+    dest_port: any
+    dest_ip: any
+
+  tasks:
+    - name: Add snort sql injection rule
+      include_role:
+        name: "ansible_security.ids_rule"
+      vars:
+        ids_rule: 'alert {{protocol}} {{source_ip}} {{source_port}} -> {{dest_ip}} {{dest_port}}  (msg:"Attempted SQL Injection"; uricontent:"/sql_injection_simulation"; classtype:attempted-admin; sid:99000030; priority:1; rev:1;)'
+        ids_rules_file: '/etc/snort/rules/local.rules'
+        ids_rule_state: present

--- a/exercises/ansible_security/2.3-incident/playbooks/sql_injection_simulation.yml
+++ b/exercises/ansible_security/2.3-incident/playbooks/sql_injection_simulation.yml
@@ -1,0 +1,9 @@
+---
+- name: start sql injection simulation
+  hosts: attacker
+  become: yes
+  gather_facts: no
+
+  tasks:
+    - name: simulate sql injection attack every 5 seconds
+      shell: "/sbin/daemonize /usr/bin/watch -n 5 curl -m 2 -s http://{{ hostvars['snort']['private_ip2'] }}/sql_injection_simulation"


### PR DESCRIPTION
...across description and playbooks.

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Having the playbooks present makes it easier for the field to run demos based on this workshop.

The QRadar exercise references `Potential DDoS Against Single Host (TCP)` but several embedded playbook fragments reference `DDoS Attack Detected`; now they all reference the former.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION

