### PR TITLE
fixing network automation workshop

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -110,7 +110,7 @@ If you haven't done so already make sure you have the repo cloned to the machine
 
 Some of the workshops require specific images provided via the AWS marketplace:
 
-  - For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/), the Arista vEOS Router [Click here](https://aws.amazon.com/marketplace/pp/B077YJYMK5/), AND the Juniper vSRX NextGen Firewall [Click here](https://aws.amazon.com/marketplace/pp/B01LYWCGDX/)
+  - For Networking you will need the Cisco CSR (Cloud Services Router) [Click here](https://aws.amazon.com/marketplace/pp/B00NF48FI2/), the Arista CloudEOS Router (PAYG) [Click here](https://aws.amazon.com/marketplace/pp/prodview-v5qiohwjlngay), **AND** the Juniper vSRX NextGen Firewall [Click here](https://aws.amazon.com/marketplace/pp/B01LYWCGDX/)
   - For F5 you will need the F5 BIG-IP [Click here](https://aws.amazon.com/marketplace/pp/B079C44MFH/)
   - For the security workshop the [Check Point CloudGuard Security Management](https://aws.amazon.com/marketplace/pp/B07KSBV1MM?qid=1613741711380&sr=0-2&ref_=srh_res_product_title) and the [Check Point CloudGuard Network Security](https://aws.amazon.com/marketplace/pp/B07LB3YN9P?ref_=aws-mp-console-subscription-detail-byol)
 

--- a/roles/manage_ec2_instances/defaults/main/main.yml
+++ b/roles/manage_ec2_instances/defaults/main/main.yml
@@ -67,7 +67,7 @@ ec2_info:
     ami: "{{ arista_ami | default(omit) }}"
     os: eos
     username: ec2-user
-    filter: "*VEOSRouter*"
+    filter: "*4.27.3F*"
     volume:
       - device_name: /dev/xvda
         ebs:


### PR DESCRIPTION
##### SUMMARY
Arista rebranded their vEOS to CloudEOS, but they also didn't tag their newest image release with any "tag" that makes this obvious.  The word Arista and CloudEOS, or even EOS is not present... so I am having to do a specific version lookup.  I have already opened a dialog with Arista to show them how this does not match best practices with AWS.

For example the newest Arista switch image we are using is: name: 4.27.3F-971505ec-86ee-48a7-a33b-54295288e797

There is no way to tell what this image is... it's just a version that is unique to Arista.  Versus what Red Hat does with Red Hat Enterprise Linux, RHEL-8.3_HVM-20210209-x86_64-0-Hourly2-GP2

If you dump the entire JSON return info for that AMI, there is also no description or tag of any kind.... so there is not another key that I can filter by either.

I am testing a fix on hardcoding this to the minor version... which "should" be unique to Arista (e.g. the new filter is name: "*4.27.3F*")

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
n/a
