### PR TITLE
Use the variable inside the uid expression rather than a hardcoded val

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/README.ja.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.ja.md
@@ -269,7 +269,7 @@ Playbook を書き直して、追加のユーザー権限を持つユーザー�
         key: "{{ myuser }}"
     - debug:
         msg:
-          - "{{ myuser }} uid: {{ getent_passwd['dev_user'].1 }}"
+          - "{{ myuser }} uid: {{ getent_passwd[myuser].1 }}"
 ```
 {% endraw %}
 

--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -254,7 +254,7 @@ Verify that the user `dev_user` was indeed created on `node1` using the followin
         key: "{{ myuser }}"
     - debug:
         msg:
-          - "{{ myuser }} uid: {{ getent_passwd['dev_user'].1 }}"
+          - "{{ myuser }} uid: {{ getent_passwd[myuser].1 }}"
 ```
 {% endraw %}
 

--- a/exercises/ansible_rhel/ansible-files/files/user_id.yml
+++ b/exercises/ansible_rhel/ansible-files/files/user_id.yml
@@ -10,4 +10,4 @@
         key: "{{ myuser }}"
     - debug:
         msg:
-          - "{{ myuser }} uid: {{ getent_passwd['dev_user'].1 }}"
+          - "{{ myuser }} uid: {{ getent_passwd[myuser].1 }}"


### PR DESCRIPTION
##### SUMMARY
This example uses a hardcoded value of 'dev_user' inside the template example, rather than using the variable containing the same value. This change references the variable rather than using the hardcoded value directly.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises
