### PR TITLE
Fixed the link from Japanese to Japanese

### DIFF
--- a/exercises/ansible_network/1-explore/README.ja.md
+++ b/exercises/ansible_network/1-explore/README.ja.md
@@ -331,7 +331,6 @@ Cisco IOS XE Software, Version 16.09.02
 
 
 ---
-[次の演習](../2-first-playbook/README.md)
+[次の演習](../2-first-playbook/README.ja.md)
 
-[Click Here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/2-first-playbook/README.ja.md
+++ b/exercises/ansible_network/2-first-playbook/README.ja.md
@@ -255,7 +255,6 @@ snmp-server community ansible-test RO
 ラボ演習 2 を完了しました
 
 ---
-[前の演習](../1-explore/README.md) | [次の演習](../3-facts/README.md)
+[前の演習](../1-explore/README.ja.md) | [次の演習](../3-facts/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/3-facts/README.ja.md
+++ b/exercises/ansible_network/3-facts/README.ja.md
@@ -228,8 +228,7 @@ screenshot](images/ansible-navigator-facts-stdout.png)
 ラボ演習 3 を完了しました
 
 ---
-[前の演習](../2-first-playbook/README.md) |
-[次の演習](../4-resource-module/README.md)
+[前の演習](../2-first-playbook/README.ja.md) |
+[次の演習](../4-resource-module/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/4-resource-module/README.ja.md
+++ b/exercises/ansible_network/4-resource-module/README.ja.md
@@ -172,7 +172,7 @@ Ansible
     * gathered
     * parsed
 
-    この演習では、これらのパラメーターの中の 2 つのみについて説明しますが、それ以外に [追加の演習](../supplemental/README.md) に説明があります。
+    この演習では、これらのパラメーターの中の 2 つのみについて説明しますが、それ以外に [追加の演習](../supplemental/README.ja.md) に説明があります。
   * `config:` - これは提供された VLAN 設定です。これはディクショナリーのリストです。最も重要なのは、モジュールが `arista.eos.vlans` から `junipernetworks.junos.vlans` に変更されると、同じ動作になることです。これにより、ネットワークエンジニアは、ベンダー構文や実装よりもネットワーク（VLAN 設定など）にフォーカスできるようになります。
 
 ### ステップ 4 - Ansible Playbook の実行
@@ -366,11 +366,10 @@ VLAN（デフォルトの VLAN 1 を含む）があります。
 ラボ演習 4 を完了しました
 
 前述したように、この演習では 2 つのリソースモジュールパラメーターのみが対象ですが、それ以外に
-[追加の演習](../supplemental/README.md) に説明があります。
+[追加の演習](../supplemental/README.ja.md) に説明があります。
 
 次の演習では、自動コントローラーの使用を開始します。
 ---
-[前の演習](../3-facts/README.md) | [次の演習](../5-explore-controller/README.md)
+[前の演習](../3-facts/README.ja.md) | [次の演習](../5-explore-controller/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/5-explore-controller/README.ja.md
+++ b/exercises/ansible_network/5-explore-controller/README.ja.md
@@ -170,8 +170,7 @@
 つのコンポーネントすべてを調べました。次の演習では、ジョブテンプレートを作成します。
 
 ---
-[前の演習](../4-resource-module/README.md) |
-[次の演習](../6-controller-job-template/README.md)
+[前の演習](../4-resource-module/README.ja.md) |
+[次の演習](../6-controller-job-template/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/6-controller-job-template/README.ja.md
+++ b/exercises/ansible_network/6-controller-job-template/README.ja.md
@@ -171,8 +171,7 @@
 ラボ演習 6 を完了しました
 
 ---
-[前の演習](../5-explore-controller/README.md) |
-[次の演習](../7-controller-survey/README.md)
+[前の演習](../5-explore-controller/README.ja.md) |
+[次の演習](../7-controller-survey/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/7-controller-survey/README.es.md
+++ b/exercises/ansible_network/7-controller-survey/README.es.md
@@ -212,6 +212,6 @@ Has probado existosamente lo siguiente:
 ¡Felicidades, has completado el ejercicio de laboratorio 7!
 
 ---
-[Ejercicio Anterior](../6--controller-job-template/README.md) | [Próximo ejercicio](../8-controller-rbac/README.es.md)
+[Ejercicio Anterior](../6-controller-job-template/README.md) | [Próximo ejercicio](../8-controller-rbac/README.es.md)
 
 [Haz click aquí para volver al taller Ansible Network Automation](../README.es.md)

--- a/exercises/ansible_network/7-controller-survey/README.ja.md
+++ b/exercises/ansible_network/7-controller-survey/README.ja.md
@@ -223,8 +223,7 @@ junos デバイスを使用している場合、この Playbook は `junos.yml` 
 ラボ演習 7 を完了しました
 
 ---
-[前の演習](../6--controller-job-template/README.md) |
-[次の演習](../8-controller-rbac/README.md)
+[前の演習](../6-controller-job-template/README.ja.md) |
+[次の演習](../8-controller-rbac/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/7-controller-survey/README.md
+++ b/exercises/ansible_network/7-controller-survey/README.md
@@ -214,6 +214,6 @@ You have successfully demonstrated
 You have completed lab exercise 7
 
 ---
-[Previous Exercise](../6--controller-job-template/README.md) | [Next Exercise](../8-controller-rbac/README.md)
+[Previous Exercise](../6-controller-job-template/README.md) | [Next Exercise](../8-controller-rbac/README.md)
 
 [Click here to return to the Ansible Network Automation Workshop](../README.md)

--- a/exercises/ansible_network/8-controller-rbac/README.ja.md
+++ b/exercises/ansible_network/8-controller-rbac/README.ja.md
@@ -260,7 +260,6 @@
 ラボ演習 8 を完了しました
 
 ---
-[前の演習](../7-controller-survey/) | [次の演習](../9-controller-workflow/README.md)
+[前の演習](../7-controller-survey/README.ja.md) | [次の演習](../9-controller-workflow/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/9-controller-workflow/README.ja.md
+++ b/exercises/ansible_network/9-controller-workflow/README.ja.md
@@ -196,10 +196,9 @@
 
 ラボ演習 9 を完了しました。これでネットワーク自動化ワークショップは終了です。ご参加いただきありがとうございました!
 
-追加の演習については、[追加の演習](../supplemental/README.md) を参照してください。
+追加の演習については、[追加の演習](../supplemental/README.ja.md) を参照してください。
 
 ---
-[前の演習](../8-controller-rbac/README.md)
+[前の演習](../8-controller-rbac/README.ja.md)
 
-[Click here to return to the Ansible Network Automation
-Workshop](../README.md)
+[Ansible Network Automation ワークショップに戻る](../README.ja.md)

--- a/exercises/ansible_network/supplemental/README.ja.md
+++ b/exercises/ansible_network/supplemental/README.ja.md
@@ -2,21 +2,15 @@
 
 これらは、すでにワークショップを完了しているか、さらに知識を習得したい受講者向けの追加の演習です。
 
-- [ネットワークリソースモジュール - 続き ](resource) - これは、[演習 4 - Ansible
-ネットワークリソースモジュール](../4-resource-module) の追加演習です - [Jinja
-テンプレートを使用したネットワーク設定](jinja) - この演習では、ネットワークエンジニアを対象に Jinja2
-を使用してネットワーク設定をテンプレート化する方法を説明します
+- [ネットワークリソースモジュール - 続き ](resource/README.ja.md) - これは、[演習 4 - Ansibleネットワークリソースモジュール](../4-resource-module/README.ja.md) の追加演習です
+- [Jinjaテンプレートを使用したネットワーク設定](jinja/README.ja.md) - この演習では、ネットワークエンジニアを対象に Jinja2を使用してネットワーク設定をテンプレート化する方法を説明します
 
 
 ## ご参加ありがとうございます
 
 Ansible ネットワーク自動化ワークショップにご参加いただき、ありがとうございます。  
 
-- Github
-ソースについては、[https://github.com/ansible/workshops](https://github.com/ansible/workshops)
-を参照してください - Ansible Network Automation の詳細は、弊社の Web サイト
-[https://www.ansible.com/use-cases/network-automation](https://www.ansible.com/use-cases/network-automation)
-を参照してください
+- Githubソースについては、[https://github.com/ansible/workshops](https://github.com/ansible/workshops)を参照してください 
+- Ansible Network Automation の詳細は、弊社の Web サイト[https://www.ansible.com/use-cases/network-automation](https://www.ansible.com/use-cases/network-automation)を参照してください
 
-![workshop
-logo](https://github.com/ansible/workshops/blob/devel/images/Ansible-Workshop-Logo.png?raw=true)
+![workshop logo](https://github.com/ansible/workshops/blob/devel/images/Ansible-Workshop-Logo.png?raw=true)


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The link of "Previous Exercise | Next Exercise" in Japanese contents pointed English contents.

I fixed the link from Japanese to Japanese

And fixed broken links in English and Español contents.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
