### PR TITLE
removing next exercise from page

### DIFF
--- a/exercises/ansible_rhel_90/6-system-roles/README.md
+++ b/exercises/ansible_rhel_90/6-system-roles/README.md
@@ -188,6 +188,6 @@ You have completed lab exercise
 ----
 **Navigation**
 <br>
-[Previous Exercise](../5-surveys) - [Next Exercise](../7-insights)
+[Previous Exercise](../5-surveys)
 <br><br>
 [Click here to return to the Ansible for Red Hat Enterprise Linux Workshop](../README.md)


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Remove moving to Exercise 7 from RHEL90 workshop

Fixes #1798 

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME

- docs


