### PR TITLE
[Exercise]  Fix supplemental resource

### DIFF
--- a/exercises/ansible_network/supplemental/resource/README.md
+++ b/exercises/ansible_network/supplemental/resource/README.md
@@ -135,7 +135,7 @@ There are two parts to this exercise:
   rtr4                       : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
   ```
 
-* The playbook did **NOT** modify the configuration.  The `state: merged` only enforces that the config provided exists on the network device.  Lets contrast this to `replaced`.  If you login to the Arista network device the `state: suspend` will still be there.
+* The playbook did **NOT** modify the configuration.  The `state: merged` only enforces that the config provided exists on the network device.  Lets contrast this to `replaced`.  If you login to the Arista network device the `state suspend` will still be there.
 
 ### Step 3 - Modify the playbook
 
@@ -188,7 +188,7 @@ There are two parts to this exercise:
   rtr2                       : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
   rtr4                       : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
   ```
-* Now examine the config on rtr2, the `state: suspend` is now gone.  Replaced will enforce (for the specified VLANs) the supplied configurations.  This means that since `state: suspend` was not supplied, and NOT the default for a VLAN, it will remove it from the network device.
+* Now examine the config on rtr2, the `state suspend` is now gone.  Replaced will enforce (for the specified VLANs) the supplied configurations.  This means that since `state: suspend` was not supplied, and NOT the default for a VLAN, it will remove it from the network device.
 
 ### Step 5 - Add a VLAN to rtr2
 

--- a/exercises/ansible_network/supplemental/resource/README.md
+++ b/exercises/ansible_network/supplemental/resource/README.md
@@ -201,7 +201,7 @@ There are two parts to this exercise:
   rtr2(config-vlan-100)#name artisanal
   ```
 
-*  We can assume that someone has created this VLAN outside of automation (e.g. they hand-crafted a VLAN i.e. artisanal VLAN)  This is referred to as "out of band" network changes.  This is very common in the network industry because a network engineer solved a problem, but then never documented or circled back to remove this configuration.  This manual cofiguration change does not match best practices or their documented policy.  This could cause issues where someone tries to use this VLAN in the future, and not aware of this configuration.
+*  We can assume that someone has created this VLAN outside of automation (e.g. they hand-crafted a VLAN i.e. artisanal VLAN)  This is referred to as "out of band" network changes.  This is very common in the network industry because a network engineer solved a problem, but then never documented or circled back to remove this configuration.  This manual configuration change does not match best practices or their documented policy.  This could cause issues where someone tries to use this VLAN in the future, and not aware of this configuration.
 
   ```bash
   rtr2#show vlan


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

fix typo and some `state: suspend` to `state suspend`.

The `state: suspend` is module parameter and the `state suspend` is arista vlan configuraion.

It seemed to confuse both.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
n/a
```
