### PR TITLE
set 'wait:true' for community.aws.route53

### DIFF
--- a/roles/aws_dns/tasks/create.yml
+++ b/roles/aws_dns/tasks/create.yml
@@ -8,4 +8,5 @@
     type: A
     overwrite: true
     value: "{{ ansible_host }}"
+    wait: true
   delegate_to: localhost

--- a/roles/code_server/tasks/codeserver.yml
+++ b/roles/code_server/tasks/codeserver.yml
@@ -11,6 +11,7 @@
     type: A
     overwrite: true
     value: "{{ ansible_host }}"
+    wait: true
   delegate_to: localhost
   register: route53_status
   when: workshop_type is defined

--- a/roles/private_automation_hub/tasks/40_dns/aws.yml
+++ b/roles/private_automation_hub/tasks/40_dns/aws.yml
@@ -40,6 +40,6 @@
     type: A
     overwrite: true
     value: "{{ ansible_host }}"
-    wait: false
+    wait: true
   delegate_to: localhost
   register: route53_status

--- a/roles/splunk_enterprise/tasks/main.yml
+++ b/roles/splunk_enterprise/tasks/main.yml
@@ -50,6 +50,7 @@
         type: A
         overwrite: true
         value: "{{ansible_host}}"
+        wait: true
       delegate_to: localhost
       when:
         - check_cert is failed

--- a/roles/workshop_attendance/tasks/aws.yml
+++ b/roles/workshop_attendance/tasks/aws.yml
@@ -8,7 +8,7 @@
     type: A
     overwrite: true
     value: "{{ ansible_host }}"
-    wait: false
+    wait: true
   delegate_to: localhost
   register: route53_status
   when:


### PR DESCRIPTION
##### SUMMARY
Some `community.aws.route53` tasks are not set to wait for Route53 DNS replication confirmation prior to continuing. This PR sets `wait:true` for those tasks where it is currently set to false.

Fixes #1826 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

