### PR TITLE
Create symlink 0.0-support-docs --> ../ansible_rhel/0.0-support-docs …

### DIFF
--- a/exercises/ansible_rhel_90/0.0-support-docs
+++ b/exercises/ansible_rhel_90/0.0-support-docs
@@ -1,0 +1,1 @@
+../ansible_rhel/0.0-support-docs


### PR DESCRIPTION
…to fix 404

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Missing `0.0-support-docs` symlink in the `exercises/ansible_rhel_90` directory causing a 404 with markdown READMEs in that directory when the `editor_intro.md` link is followed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #1808 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
