### PR TITLE
Add ability to download manifest from protected website and RHPDS use…

### DIFF
--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -205,6 +205,17 @@ These are the ways to integrate your license file with the workshop:
   manifest_download_password: password
   ```
 
+### Automating the download of aap.tar.gz 
+
+If you have the aap.tar.gz tarball in a secure URL, you can automate the downloading of it by specifying the following variables.
+Note that the tarball specified in the URL must match the SHA value defined in provided_sha_value
+
+  ```
+  aap_download_url: https://www.example.com/protected/aap.tar.gz
+  aap_download_user: username
+  aap_download_password: password
+  ```
+
 ### Additional examples
 
 For more extra_vars examples, look at the following:

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -163,7 +163,7 @@ In order to use Automation controller (i.e. `controllerinstall: true`), which is
 
 **How do you use the manifest.zip with the workshop?**
 
-There are currently two ways to integrate your license file with the workshop:
+These are the ways to integrate your license file with the workshop:
 
 1. Put the manifest.zip file into provisioner folder
 
@@ -195,6 +195,15 @@ There are currently two ways to integrate your license file with the workshop:
   >
   >base64 is not encryption, if you require encryption you need to work within your CI system or Automation controller to encrypt the base64 encoded manifest.zip.
 
+3. Download the manifest.zip from a URL
+
+  If you specify the following variables, the provisioner will download the manifest.zip from an authenticated URL:
+
+  ```
+  manifest_download_url: https://www.example.com/protected/manifest.zip
+  manifest_download_user: username
+  manifest_download_password: password
+  ```
 
 ### Additional examples
 

--- a/provisioner/provision_lab.yml
+++ b/provisioner/provision_lab.yml
@@ -188,18 +188,32 @@
           PROVISIONER SUMMARY
           *******************
           - Workshop name is {{ ec2_name_prefix }}
+          {% if not rhpds_info_output | default(false) | bool %}
           - Instructor inventory is located at  {{ playbook_dir }}/{{ ec2_name_prefix }}/instructor_inventory.txt
           - Private key is located at {{ playbook_dir }}/{{ ec2_name_prefix }}/{{ ec2_name_prefix }}-private.pem
+          {% endif %}
           {% if attendance %}
           - {{ hostvars['attendance-host'].login_website_information | default("attendance feature is not functioning") }}
+          {% if rhpds_info_output | default(false) | bool %}
+          - Admin password: {{ admin_password }}
+          {% endif %}
           {% endif %}
 
+          {% if not rhpds_info_output | default(false) | bool %}
           FAILURES
           *******************
           {{ dns_information }}
           {{ callback_information }}
           {{ demo_information }}
+          {% endif %}
 
     - name: Print Summary Information
+      when: not rhpds_info_output | default(false) | bool
       debug:
         msg: "{{ summary_information }}"
+
+    - name: Print Summary Information
+      when: rhpds_info_output | default(false) | bool
+      debug:
+        msg: "user.info: {{ summary_information }}"
+

--- a/roles/aap_download/tasks/09_download_url.yml
+++ b/roles/aap_download/tasks/09_download_url.yml
@@ -1,0 +1,25 @@
+---
+- name: Download aap.tar.gz from specified URL
+  delegate_to: localhost
+  block:
+    - name: Enforce use of user/password for AAP download
+      ansible.builtin.assert:
+        that:
+          - aap_download_url.startswith('https://')
+          - aap_download_user is defined
+          - aap_download_password is defined
+        fail_msg: >-
+          aap_download_url must be secure and requires aap_download_user
+          and aap_download_password.
+
+    - name: Download AAP tarball
+      ansible.builtin.get_url:
+        url: "{{ aap_download_url }}"
+        dest: "{{ playbook_dir }}/aap.tar.gz"
+        username: "{{ aap_download_user }}"
+        password: "{{ aap_download_password }}"
+        force_basic_auth: true
+      register: download_aap_tarball
+      until: download_aap_tarball is not failed
+      retries: 15
+      delay: 20

--- a/roles/aap_download/tasks/main.yml
+++ b/roles/aap_download/tasks/main.yml
@@ -5,8 +5,18 @@
     checksum_algorithm: sha256
   register: stat_var
 
+- name: attempt to download specified AAP from specified URL if we don't already have it
+  when:
+    - aap_download_url is defined
+    - stat_var.stat.checksum | default("") != provided_sha_value
+  block:
+    - name: download aap.tar.gz from specified URL
+      include_tasks: 09_download_url.yml
+
 - name: attempt to download specified AAP if we don't already have it
-  when: stat_var.stat.checksum | default("") != provided_sha_value
+  when:
+    - aap_download_url is not defined
+    - stat_var.stat.checksum | default("") != provided_sha_value
   block:
     - name: download aap.tar.gz from access.redhat.com
       include_tasks: 10_download.yml

--- a/roles/workshop_check_setup/tasks/controller.yml
+++ b/roles/workshop_check_setup/tasks/controller.yml
@@ -4,6 +4,28 @@
     path: "{{ output_dir }}"
     state: directory
 
+- name: Download manifest.zip
+  when:
+    - manifest_download_url is defined
+  block:
+    - name: Enforce use of user/password for manifest download
+      ansible.builtin.assert:
+        that:
+          - manifest_download_url.startswith('https://')
+          - manifest_download_user is defined
+          - manifest_download_password is defined
+        fail_msg: >-
+          manifest_download_url must be secure and requires manifest_download_user
+          and manifest_download_password.
+
+    - name: Download manifest.zip
+      ansible.builtin.get_url:
+        url: "{{ manifest_download_url }}"
+        dest: "{{ playbook_dir }}/manifest.zip"
+        username: "{{ manifest_download_user }}"
+        password: "{{ manifest_download_password }}"
+        force_basic_auth: true
+
 - name: check license block
   block:
     - name: Check that the manifest.zip exists


### PR DESCRIPTION
…r.info output.

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Add ability to download manifest from protected website and RHPDS user.info output.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
