### PR TITLE
fix: changing eei for network backup conf

### DIFF
--- a/exercises/ansible_network/6-controller-job-template/README.md
+++ b/exercises/ansible_network/6-controller-job-template/README.md
@@ -47,7 +47,7 @@ To run an Ansible Playbook in Automation controller we need to create a **Job Te
   |  Job Type |  Run |
   |  Inventory |  Workshop Inventory |
   |  Project |  Workshop Project |
-  |  Execution Environment | Default execution environment |
+  |  Execution Environment | network workshop execution environment |
   |  Playbook |  playbooks/network_backup.yml |
   |  Credential |  Workshop Credential |
 


### PR DESCRIPTION
Changing to network workshop execution environment because default eei shows:  ERROR! couldn't resolve module/action 'ansible.controller.job_template'. This often indicates a misspelling, missing collection, or incorrect module path.

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changing to network workshop execution environment because default eei shows:  ERROR! couldn't resolve module/action 'ansible.controller.job_template'. This often indicates a misspelling, missing collection, or incorrect module path.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs
- decks
- provisioner
- demos

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The job template fails with default eei

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
