### PR TITLE
Update smart_mgmt.yml

### DIFF
--- a/provisioner/workshop_specific/smart_mgmt.yml
+++ b/provisioner/workshop_specific/smart_mgmt.yml
@@ -70,9 +70,9 @@
             - host
         injectors:
           env:
-            FOREMAN_SERVER: "{% raw %}{{ '{{host}}' }}{% endraw %}"
-            FOREMAN_USER: "{% raw %}{{ '{{username}}' }}{% endraw %}"
-            FOREMAN_PASSWORD: "{% raw %}{{ '{{password}}' }}{% endraw %}"
+            FOREMAN_SERVER: !unsafe '{{ host }}'
+            FOREMAN_USER: !unsafe '{{ username}}'
+            FOREMAN_PASSWORD: !unsafe '{{ password }}'
             FOREMAN_VALIDATE_CERTS: 'false'
       - name: GitHub_Personal_Access_Token
         description: Credential for GitHub repo operations automation
@@ -89,7 +89,7 @@
             - personal_access_token
         injectors:
           env:
-            MY_PA_TOKEN: "{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}"
+            MY_PA_TOKEN: !unsafe '{{ personal_access_token }}'
     controller_credentials:
       - name: Satellite Credential
         credential_type: Satellite_Collection


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY

When creating credential types for smart management workshop "{% raw %}{{ '{{ variable }}' }}{% endraw %}" was not being respected and causing the provisioner to fail, changing to !unsafe corrects this.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
{
  "msg": "An unhandled exception occurred while templating '[{'name': 'Satellite_Collection', 'description': 'Credential for redhat.satellite collection', 'kind': 'cloud', 'inputs': {'fields': [{'type': 'string', 'id': 'username', 'label': 'Satellite Username'}, {'type': 'string', 'id': 'password', 'label': 'Satellite Password', 'secret': True}, {'type': 'string', 'id': 'host', 'label': 'Satellite Hostname'}], 'required': ['username', 'password', 'host']}, 'injectors': {'env': {'FOREMAN_SERVER': \"{% raw %}{{ '{{host}}' }}{% endraw %}\", 'FOREMAN_USER': \"{% raw %}{{ '{{username}}' }}{% endraw %}\", 'FOREMAN_PASSWORD': \"{% raw %}{{ '{{password}}' }}{% endraw %}\", 'FOREMAN_VALIDATE_CERTS': 'false'}}}, {'name': 'GitHub_Personal_Access_Token', 'description': 'Credential for GitHub repo operations automation', 'kind': 'cloud', 'inputs': {'fields': [{'type': 'string', 'id': 'personal_access_token', 'label': 'Personal Access Token', 'secret': True, 'help_text': 'GitHub Personal Access Token', 'multiline': True}], 'required': ['personal_access_token']}, 'injectors': {'env': {'MY_PA_TOKEN': \"{% raw %}{{ '{{ personal_access_token }}' }}{% endraw %}\"}}}]'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on ({% raw %}{{ '{{host}}' }}{% endraw %}): unhashable type: 'set'",
  "_ansible_no_log": null
}
```
After
```
{
  "changed": true,
  "id": 27,
  "invocation": {
    "module_args": {
      "name": "Satellite_Collection",
      "description": "Credential for redhat.satellite collection",
      "injectors": {
        "env": {
          "FOREMAN_SERVER": "{{ host }}",
          "FOREMAN_USER": "{{ username}}",
          "FOREMAN_PASSWORD": "{{ password }}",
          "FOREMAN_VALIDATE_CERTS": "false"
        }
      },
      "inputs": {
        "fields": [
          {
            "type": "string",
            "id": "username",
            "label": "Satellite Username"
          },
          {
            "type": "string",
            "id": "password",
            "label": "Satellite Password",
            "secret": true
          },
          {
            "type": "string",
            "id": "host",
            "label": "Satellite Hostname"
          }
        ],
        "required": [
          "username",
          "password",
          "host"
        ]
      },
      "kind": "cloud",
      "state": "present",
      "controller_username": "admin",
      "controller_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
      "controller_host": "https://35.175.229.71",
      "validate_certs": false,
      "controller_oauthtoken": null,
      "controller_config_file": null,
      "new_name": null
    }
  },
  "warnings": [
    "You are running collection version 4.2.1 but connecting to Red Hat Ansible Automation Platform version 4.1.0"
  ],
  "_ansible_no_log": false,
  "__controller_credential_type_item": {
    "name": "Satellite_Collection",
    "description": "Credential for redhat.satellite collection",
    "kind": "cloud",
    "inputs": {
      "fields": [
        {
          "type": "string",
          "id": "username",
          "label": "Satellite Username"
        },
        {
          "type": "string",
          "id": "password",
          "label": "Satellite Password",
          "secret": true
        },
        {
          "type": "string",
          "id": "host",
          "label": "Satellite Hostname"
        }
      ],
      "required": [
        "username",
        "password",
        "host"
      ]
    },
    "injectors": {
      "env": {
        "FOREMAN_SERVER": "{{ host }}",
        "FOREMAN_USER": "{{ username}}",
        "FOREMAN_PASSWORD": "{{ password }}",
        "FOREMAN_VALIDATE_CERTS": "false"
      }
    }
  },
  "ansible_loop_var": "__controller_credential_type_item",
  "_ansible_item_label": {
    "name": "Satellite_Collection",
    "description": "Credential for redhat.satellite collection",
    "kind": "cloud",
    "inputs": {
      "fields": [
        {
          "type": "string",
          "id": "username",
          "label": "Satellite Username"
        },
        {
          "type": "string",
          "id": "password",
          "label": "Satellite Password",
          "secret": true
        },
        {
          "type": "string",
          "id": "host",
          "label": "Satellite Hostname"
        }
      ],
      "required": [
        "username",
        "password",
        "host"
      ]
    },
    "injectors": {
      "env": {
        "FOREMAN_SERVER": "{{ host }}",
        "FOREMAN_USER": "{{ username}}",
        "FOREMAN_PASSWORD": "{{ password }}",
        "FOREMAN_VALIDATE_CERTS": "false"
      }
    }
  }
}
```