### PR TITLE
[Windows] Fix the students VSCode Workspace URL

### DIFF
--- a/roles/workshop_attendance/templates/workshop.sql.j2
+++ b/roles/workshop_attendance/templates/workshop.sql.j2
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS `users` (
       {% if hostvars[host].student is defined and "student" + number | string == hostvars[host].student %}
       INSERT INTO `users` (`id`, `ip`, `vscode`, `vscode_display`, `gitlab`, `hub`, `controller`, `username`, `password`) VALUES ({{ number }},'{{ hostvars[host].ansible_host }}',
       {% if workshop_type == "windows" %}
-        'https://student{{ number }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/editor/?folder=vscode-remote%3A%2F%2Fstudent{{ number }}-code.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}%2Feditor%2Fhome%2Fstudent%2Fwindows-workshop%2Fworkshop_project',
+        'https://student{{ number }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/editor/?folder=vscode-remote%3A%2F%2Fstudent{{ number }}-code.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}%2Fhome%2Fstudent%2Fwindows-workshop%2Fworkshop_project',
       {% else %}
         'https://student{{ number }}.{{ ec2_name_prefix }}.{{ workshop_dns_zone }}/editor',
       {% endif %}


### PR DESCRIPTION


##### SUMMARY
The students workspace URL was broken, as it was pointing to /editor/home/student...  this fixes the url.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION

