### PR TITLE
Update README.md

### DIFF
--- a/exercises/ansible_network/6-controller-job-template/README.md
+++ b/exercises/ansible_network/6-controller-job-template/README.md
@@ -47,7 +47,7 @@ To run an Ansible Playbook in Automation controller we need to create a **Job Te
   |  Job Type |  Run |
   |  Inventory |  Workshop Inventory |
   |  Project |  Workshop Project |
-  |  Execution Environment | network workshop execution environment |
+  |  Execution Environment | Default execution environment |
   |  Playbook |  playbooks/network_backup.yml |
   |  Credential |  Workshop Credential |
 


### PR DESCRIPTION
The workshop now use Default execution environment as per the screenshot. (images/controller_backup.png)

<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
The workshop now use Default execution environment as per the screenshot. (images/controller_backup.png)
We need to remove the network workshop execution environment because it fails the exercise. (Documentation)
The actual screenshot report : Default execution environment

##### ISSUE TYPE


- Docs Pull Request


##### COMPONENT NAME

- docs



