### PR TITLE
workshops devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 			"enableNonRootDocker": "true",
 			"moby": "true"
 		},
-		"ghcr.io/devcontainers/features/python:1": {}
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/devcontainers/features/aws-cli:1": {}
 	},
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,44 +1,48 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ubuntu
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-in-docker
 {
-	"name": "Ubuntu",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
-		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
-		"args": { "VARIANT": "ubuntu-22.04" }
-	},
+	"name": "Docker in Docker",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
 
-		// Configure tool-specific properties.
-		"customizations": {
-			// Configure properties specific to VS Code.
-			"vscode": {
-				// Set *default* container specific settings.json values on container create.
-				"settings": { 
-					"ansible.executionEnvironment.image": "quay.io/acme_corp/workshop_ee:latest",
-					"ansible.ansible.useFullyQualifiedCollectionNames" : true,
-					"ansible.ansibleLint.enabled" : true
-				},
-				// Add the IDs of extensions you want installed when the container is created.
-				"extensions": [
-					"ms-python.python",
-					"redhat.ansible"
-				]
-			}
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest",
+			"enableNonRootDocker": "true",
+			"moby": "true"
 		},
+		"ghcr.io/devcontainers/features/python:1": {}
+	},
+	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user ansible-navigator",
+	// "postCreateCommand": "pip install ansible-navigator",
+	"postCreateCommand": "pip install -r ${containerWorkspaceFolder}/requirements.txt",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
-	"features": {
-		"docker-in-docker": "latest",
-		"github-cli": "latest",
-		"aws-cli": "latest",
-		"sshd": "latest",
-		"python": "3.9"
-	}
+	// VS Code extensions to install
+	// "extensions": ["redhat.ansible"],
+
+	// Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": { 
+                "ansible.executionEnvironment.image": "quay.io/acme_corp/workshop_ee:latest",
+                "ansible.ansible.useFullyQualifiedCollectionNames" : true,
+                "ansible.ansibleLint.enabled" : true
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-python.python",
+                "redhat.ansible"
+            ]
+        }
+    }
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+
 }

--- a/provisioner/README.md
+++ b/provisioner/README.md
@@ -32,6 +32,7 @@ The `github.com/ansible/workshops` contains an Ansible Playbook `provision_lab.y
     * [Accessing instructor inventory](#accessing-instructor-inventory)
     * [DNS](#dns)
     * [Smart Management](#smart-management)
+    * [devcontainer(optional)](#devcontainer)
   * [Developer Mode and understanding collections](#developer-mode-and-understanding-collections)
   * [Lab Teardown](#lab-teardown)
   * [Demos](#demos)
@@ -273,6 +274,12 @@ This means that each student workbench will get an individual DNS entry.  For ex
 The Smart Management Lab relies on a prebuilt AMI for Red Hat Satellite Server. An example for building this AMI can be found [here](https://github.com/willtome/ec2-image-build).
 
 The Smart Management Lab also requires AWS DNS to be enabled. See [sample vars](./sample_workshops/sample-vars-smart_mgmt.yml) for required configuration.
+
+### devcontainer
+
+For convenience, a devcontainer has been configured for use within this project. This setup allows workshop developers to run the workspace along with provisioner within a Docker container. The devcontainer has support for docker-in-docker so that `ansible-navigator` can run against the workshop execution environment to provision workshops. 
+
+See the `devcontainer.json` in the `.devcontainer` directory at the top level of this repository. For more information regarding devcontainers, see [here](https://code.visualstudio.com/docs/devcontainers/containers).
 
 ## Developer Mode and understanding collections
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible-core>=2.11
+ansible-navigator==2.2.0
 paramiko==2.8.1
 boto3==1.21.15
 netaddr==0.8.0


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improving devcontainer. This adds features for docker-in-docker and automatically installing aws cli. 

> "A [devcontainer.json file](https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file) in your project tells VS Code how to access (or create) a development container with a well-defined tool and runtime stack. This container can be used to run an application or to separate tools, libraries, or runtimes needed for working with a codebase."

devcontainers and docker-in-docker brings a predictable ansible control host to docker supported platforms. For instance, some issues only pop up when provisioning a workshop from MacOS. With devcontainers, you are able to open the project in a new container based on Ubuntu and then run the provisioner inside that container. `ansible-navigator` works because docker-in-docker support has been added to the devcontainer. The end result is even though the project has been cloned on MacOS, the provisioning playbook is executed from an Ubuntu host leveraging the workshop execution environment. 

To try it out, install docker. Next, clone the repo locally. When you open it up in VS Code, you should be prompted in the lower right to open workspace in a container. The container will build and VS Code will re-open.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner
