### PR TITLE
Fix EE name in network exercise 1

### DIFF
--- a/exercises/ansible_network/1-explore/README.es.md
+++ b/exercises/ansible_network/1-explore/README.es.md
@@ -111,7 +111,7 @@ $ ansible-navigator images
 >
 > La salida mostrada puede diferir de la anteriomente mostrada
 
-Este comando da información sobre todos los Entornos de Ejecución actualmente instalados (EE para abreviar). Investiga un EE pulsando el número correspondiente. Por ejemplo, pulsando **2** con el ejemplo anterior, abrirá el EE `ee-supported-rhel8`:
+Este comando da información sobre todos los Entornos de Ejecución actualmente instalados (EE para abreviar). Investiga un EE pulsando el número correspondiente. Por ejemplo, pulsando **0** con el ejemplo anterior, abrirá el EE `network-ee`:
 
 ![ee main menu](images/navigator-ee-menu.png)
 
@@ -132,7 +132,7 @@ ansible-navigator:
     - /home/student/lab_inventory/hosts
 
   execution-environment:
-    image: registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0
+    image: quay.io/acme_corp/network-ee:latest
     enabled: true
     container-engine: podman
     pull-policy: missing

--- a/exercises/ansible_network/1-explore/README.ja.md
+++ b/exercises/ansible_network/1-explore/README.ja.md
@@ -128,7 +128,7 @@ $ ansible-navigator images
 > 表示される出力は、上記の出力とは異なる場合があります
 
 このコマンドは、現在インストールされているすべての実行環境（略してEE）に関する情報を提供します。対応する番号を押すことで、EE
-を調べることができます。例えば、上記の例で **2** を押すと、`ee-supported-rhel8` の実行環境が表示されます。
+を調べることができます。例えば、上記の例で **0** を押すと、`network-ee` の実行環境が表示されます。
 
 ![ee メインメニュー](images/navigator-ee-menu.png)
 
@@ -151,7 +151,7 @@ ansible-navigator:
     - /home/student/lab_inventory/hosts
 
   execution-environment:
-    image: registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0
+    image: quay.io/acme_corp/network-ee:latest
     enabled: true
     container-engine: podman
     pull-policy: missing

--- a/exercises/ansible_network/1-explore/README.md
+++ b/exercises/ansible_network/1-explore/README.md
@@ -110,7 +110,7 @@ $ ansible-navigator images
 >
 > The output  you see might differ from the above output
 
-This command gives you information about all currently installed Execution Environments or EEs for short.  Investigate an EE by pressing the corresponding number.  For example pressing **2** with the above example will open the `ee-supported-rhel8` execution environment:
+This command gives you information about all currently installed Execution Environments or EEs for short.  Investigate an EE by pressing the corresponding number.  For example pressing **0** with the above example will open the `network-ee` execution environment:
 
 ![ee main menu](images/navigator-ee-menu.png)
 
@@ -131,7 +131,7 @@ ansible-navigator:
     - /home/student/lab_inventory/hosts
 
   execution-environment:
-    image: registry.redhat.io/ansible-automation-platform-20-early-access/ee-supported-rhel8:2.0.0
+    image: quay.io/acme_corp/network-ee:latest
     enabled: true
     container-engine: podman
     pull-policy: missing


### PR DESCRIPTION
##### SUMMARY
Corrects the execution environment name in exercise 1 of the network workshop, so that it matches the existing image.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
The image showing the EE pane of ansible-navigator only shows one EE (network-ee), but the exercise indicated that the third EE named ee-supported-rhel8 shoudl be chosen.