### PR TITLE
fix Cisco images for network workshop

### DIFF
--- a/roles/configure_routers/tasks/juniper_default.yml
+++ b/roles/configure_routers/tasks/juniper_default.yml
@@ -14,6 +14,9 @@
     - "rollback"
     - "set system root-authentication plain-text-password"
     - "commit"
+  register: change_password
+  until: change_password is success
+  retries: 5
 
 - name: turn on netconf on port 830
   junipernetworks.junos.junos_netconf:

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
@@ -7,7 +7,7 @@
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:
-          name: "cisco_CSR-16.09.08-BYOL*"
+          name: "cisco_CSR-17.03.06-BYOL-624f5bb1*"
           architecture: "x86_64"
       register: cisco_ami_list
 


### PR DESCRIPTION
##### SUMMARY
fix Cisco images for network workshop

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/6537680/232802858-fb5e2450-695d-4e4f-90ff-437b36dd259b.png)

now switching to->
```
    - name: find ami for cisco (NETWORKING MODE)
      ec2_ami_info:
        region: "{{ ec2_region }}"
        owners: "679593333241"
        filters:
          name: "cisco_CSR-17.03.06-BYOL-624f5bb1*"
          architecture: "x86_64"
      register: cisco_ami_list
```