### PR TITLE
Add petname library for ripu workshop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests==2.22.0
 pywinrm==0.4.1
 requests-credssp==1.2.0
 ipaddr==2.2.0
+petname==2.6


### PR DESCRIPTION
##### SUMMARY
RHEL In Place Upgrade workshop utilizes `community.general.random_pet` module to generate random names for RHEL nodes. This module requires the presence of the pip library `petname`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner