### PR TITLE
Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf

### DIFF
--- a/roles/code_server/tasks/codeserver_always.yml
+++ b/roles/code_server/tasks/codeserver_always.yml
@@ -1,4 +1,18 @@
 ---
+- name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf
+  ansible.builtin.lineinfile:
+    path: /etc/nginx/conf.d/automation-controller.nginx.conf
+    regexp: '^(.*)add_header X-Frame-Options \"DENY\"\;'
+    line: >-
+      \1add_header Content-Security-Policy "frame-ancestors 'self';";
+    backrefs: yes
+    owner: root
+    group: root
+    mode: '0644'
+  register: add_header_csp
+  retries: 10
+  until: add_header_csp is not changed
+
 - name: Apply our systemd service file (instead of RPM file)
   ansible.builtin.template:
     src: code-server.service.j2


### PR DESCRIPTION
##### SUMMARY
Markdown files in code-server fail to render in new preview markdown/html tabs due to:
`Refused to display 'https://<fqdn>/' in a frame because it set 'X-Frame-Options' to 'deny'.`
In order to allow the new frame to render, CSP frame-ancestors need to be implemented instead.
Thus, in `/etc/nginx/conf.d/automation-controller.nginx.conf` the following directive:
`add_header X-Frame-Options "DENY";`
...is changed to:
`add_header Content-Security-Policy "frame-ancestors 'self';";`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
