### PR TITLE
Implement nginx csp frame ancestors for all pre_build AMIs

### DIFF
--- a/roles/code_server/tasks/codeserver_always.yml
+++ b/roles/code_server/tasks/codeserver_always.yml
@@ -4,8 +4,6 @@
     path: /etc/nginx/conf.d/automation-controller.nginx.conf
   register: automation_controller_nginx_conf_file
 
-  when: not automation_controller_nginx_conf_file.stat.exists
-
 - name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf
   ansible.builtin.lineinfile:
     path: /etc/nginx/conf.d/automation-controller.nginx.conf

--- a/roles/code_server/tasks/codeserver_always.yml
+++ b/roles/code_server/tasks/codeserver_always.yml
@@ -1,16 +1,15 @@
 ---
-- name: editor block - update nginx configuration to support code server
-  blockinfile:
-    block: "{{ lookup('template', 'nginx_instruqt.conf') }}"
-    dest: /etc/nginx/conf.d/automation-controller.nginx.conf
-    insertbefore: "location / "
+- name: Verify presence of automation-controller.nginx.conf
+  ansible.builtin.stat:
+    path: /etc/nginx/conf.d/automation-controller.nginx.conf
+  register: automation_controller_nginx_conf_file
 
-# Make sure we can re-run the automation platform installer during a lab without killing code-server access
-- name: update Ansible installer nginx configuration template to support code server
-  blockinfile:
-    block: "{{ lookup('template', 'nginx_instruqt.conf') }}"
-    dest: "{{ aap_dir }}/collections/ansible_collections/ansible/automation_platform_installer/roles/automationcontroller/templates/automation-controller.nginx.conf.j2"
-    insertbefore: "location / "
+- name: Copy /etc/nginx/nginx.conf file on controller to conf.d/automation-controller.nginx.conf
+  ansible.builtin.copy:
+    src: /etc/nginx/nginx.conf
+    dest: /etc/nginx/conf.d/automation-controller.nginx.conf
+    remote_src: yes
+  when: not automation_controller_nginx_conf_file.stat.exists
 
 - name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf
   ansible.builtin.lineinfile:

--- a/roles/code_server/tasks/codeserver_always.yml
+++ b/roles/code_server/tasks/codeserver_always.yml
@@ -1,4 +1,17 @@
 ---
+- name: editor block - update nginx configuration to support code server
+  blockinfile:
+    block: "{{ lookup('template', 'nginx_instruqt.conf') }}"
+    dest: /etc/nginx/conf.d/automation-controller.nginx.conf
+    insertbefore: "location / "
+
+# Make sure we can re-run the automation platform installer during a lab without killing code-server access
+- name: update Ansible installer nginx configuration template to support code server
+  blockinfile:
+    block: "{{ lookup('template', 'nginx_instruqt.conf') }}"
+    dest: "{{ aap_dir }}/collections/ansible_collections/ansible/automation_platform_installer/roles/automationcontroller/templates/automation-controller.nginx.conf.j2"
+    insertbefore: "location / "
+
 - name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf
   ansible.builtin.lineinfile:
     path: /etc/nginx/conf.d/automation-controller.nginx.conf

--- a/roles/code_server/tasks/codeserver_always.yml
+++ b/roles/code_server/tasks/codeserver_always.yml
@@ -4,11 +4,6 @@
     path: /etc/nginx/conf.d/automation-controller.nginx.conf
   register: automation_controller_nginx_conf_file
 
-- name: Copy /etc/nginx/nginx.conf file on controller to conf.d/automation-controller.nginx.conf
-  ansible.builtin.copy:
-    src: /etc/nginx/nginx.conf
-    dest: /etc/nginx/conf.d/automation-controller.nginx.conf
-    remote_src: yes
   when: not automation_controller_nginx_conf_file.stat.exists
 
 - name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in automation-controller.nginx.conf
@@ -24,6 +19,22 @@
   register: add_header_csp
   retries: 10
   until: add_header_csp is not changed
+  when: automation_controller_nginx_conf_file.stat.exists
+
+- name: Replace add_header X-Frame-Options DENY with CSP frame-ancestors self in /etc/nginx/nginx.conf
+  ansible.builtin.lineinfile:
+    path: /etc/nginx/nginx.conf
+    regexp: '^(.*)add_header X-Frame-Options \"DENY\"\;'
+    line: >-
+      \1add_header Content-Security-Policy "frame-ancestors 'self';";
+    backrefs: yes
+    owner: root
+    group: root
+    mode: '0644'
+  register: add_header_csp
+  retries: 10
+  until: add_header_csp is not changed
+  when: not automation_controller_nginx_conf_file.stat.exists
 
 - name: Apply our systemd service file (instead of RPM file)
   ansible.builtin.template:


### PR DESCRIPTION
##### SUMMARY
Early controller pre_build AMIs utilized the default nginx.conf, later builds utilized conf.d/automation-controller.nginx.conf for configuration. This PR implements the proper nginx csp frame ancestors configuration for both scenarios.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner