### PR TITLE
Updates to config as code excercise

### DIFF
--- a/exercises/ansible_config_as_code/0-setup/README.md
+++ b/exercises/ansible_config_as_code/0-setup/README.md
@@ -6,7 +6,7 @@ In this section we will show you step by step how to add pre commit linting to a
 
 If you are using the Workshop, a Workshop project should be available in your VSCode for you to push to the Workshop Gitea server. Create the files in this project folder.
 
-NOTE: If when you click on the Explorer tab that looks like two pieces of paper and you see "Open Folder" click on that. In the popup window click windows-workshop/workshop_project/ (full path is: `/home/student/windows-workshop/workshop_project`) then click "ok". If prompted select the check box and "Yes, I trust the authors" option. You should now see a readme that has a typo saying Welcome to Windows Automation workshop.
+<mark style="background-color: yellow">NOTE: If when you click on the Explorer tab that looks like two pieces of paper and you see "Open Folder" click on that. In the popup window click windows-workshop/workshop_project/ (full path is: `/home/student/windows-workshop/workshop_project`) then click "ok". If prompted select the check box and "Yes, I trust the authors" option. You should now see a readme that has a typo saying Welcome to Windows Automation workshop.</mark>
 
 ## Step 1
 

--- a/exercises/ansible_config_as_code/1-ee/README.md
+++ b/exercises/ansible_config_as_code/1-ee/README.md
@@ -20,7 +20,7 @@ Further documentation for those who are interested to learn more see:
 Install our ee_utilities collection and containers.podman using `ansible-galaxy` command.
 
 ```console
-ansible-galaxy collection install infra.ee_utilities containers.podman community.general
+ansible-galaxy collection install infra.ee_utilities:2.0.8 containers.podman community.general
 ```
 
 Further documentation for those who are interested to learn more see:


### PR DESCRIPTION

##### SUMMARY
Fixes issue where cert failed on the vscode interface pushing image to Hub.
Fixes issue where newer version of ee_utilities pulled which does not make ee files compatible with version 1.2.0 of ansible-builder that is available in the demo. -> will fix and update instructions once 2.4 is available for use, as is compatible with builder v3/AAP 2.4
added emphasis on a commonly missed step by users.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME

- exercises
