### PR TITLE
make leapp-supplements repo disabled by default

### DIFF
--- a/exercises/ansible_ripu/1.5-custom-modules/README.md
+++ b/exercises/ansible_ripu/1.5-custom-modules/README.md
@@ -65,7 +65,7 @@ There is a collection of example custom actor at the GitHub repo [oamg/leapp-sup
 - Now we will install the RPM package that provides our custom actor. Run the following command on your pet app server:
 
   ```
-  sudo yum -y install leapp-upgrade-\*-supplements
+  sudo yum -y --enablerepo=leapp-supplements install leapp-upgrade-\*-supplements
   ```
 
   > **Note**

--- a/roles/webservers/tasks/ripu.yml
+++ b/roles/webservers/tasks/ripu.yml
@@ -26,3 +26,4 @@
     description: Leapp custom actors for workshop demo
     baseurl: https://people.redhat.com/bmader/leapp-supplements-demo/RHEL/$releasever/$basearch
     gpgcheck: false
+    enabled: false


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Changing leapp-supplements yum repo config to disabled by default. 

Fixes provisioning failures happening because of new cert issue with people website. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before, provisioning fails with this when upgrading instances:
```
https://people.redhat.com/bmader/leapp-supplements-demo/RHEL/7Server/x86_64/repodata/repomd.xml: [Errno 14] curl#60 - "Peer's Certificate issuer is not recognized."
Trying other mirror.
It was impossible to connect to the Red Hat servers.
```
After, no provisioning failure. 
