### PR TITLE
Fixing playbooks YAML indentation issues in the French documentation

### DIFF
--- a/exercises/ansible_windows/3-playbook/README.fr.md
+++ b/exercises/ansible_windows/3-playbook/README.fr.md
@@ -65,9 +65,9 @@ Section 2: Definir votre Play
 Maintenant que nous avons le fichier `install_iis.yml`, commençons par écrire le play et comprendre ce que chaque ligne accomplit
 
 ```yaml
-    ---
-    - name: install the iis web service
-      hosts: windows
+---
+- name: Install the iis web service
+  hosts: windows
 ```
 
 * `---` Définit le début du fichier YAML
@@ -86,26 +86,27 @@ Si vous souhaitez voir l'intégralité du play pour référence, passez au bas d
 
 <!-- {% raw %} -->
 ```yaml
-      tasks:
-        - name: install iis
-         win_feature:
-           name: Web-Server
-           state: present
+  tasks:
+    - name: Install iis
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
 
-        - name: start iis service
-         win_service:
-           name: W3Svc
-           state: started
+    - name: Start iis service
+      ansible.windows.win_service:
+        name: W3Svc
+        state: started
 
-        - name: Create website index.html
-         win_copy:
-           content: "{{ iis_test_message }}"
-           dest: C:\Inetpub\wwwroot\index.html
+    - name: Create website index.html
+      ansible.windows.win_copy:
+        content: "{{ iis_test_message }}"
+        dest: C:\Inetpub\wwwroot\index.html
 
-        - name: Show website address
-         debug:
-           msg: "http://{{ ansible_host }}"
+    - name: Show website address
+      ansible.builtin.debug:
+        msg: http://{{ ansible_host }}
 ```
+
 <!-- {% endraw %} -->
 
 * `tasks:` Cela signifie qu'une ou plusieurs tâches sont sur le point d'être définies
@@ -115,27 +116,30 @@ Si vous souhaitez voir l'intégralité du play pour référence, passez au bas d
 <!-- -->
 
 ```yaml
-    win_feature:
-      name: Web-Server
-      state: present
+    - name: Install iis
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
 ```
 
 * Ces trois lignes appellent le module Ansible `win_feature` pour installer le serveur Web IIS. [Cliquez ici](https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_feature_module.html) pour voir les options disponibles du module `win_feature`.
 
 <!-- -->
 ```yaml
-    win_service:
-      name: W3Svc
-      state: started
+    - name: Start iis service
+      ansible.windows.win_service:
+        name: W3Svc
+        state: started
 ```
 
 * Les lignes suivantes utilisent le module ansible `win_service` pour démarrer le service IIS. Le module `win_service` est le meilleur moyen pour contrôler les services sur les hôtes distants.[Cliquez ici](https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_service_module.html) pour voir les options disponibles du module `win_service`.
 
 <!-- {% raw %} -->
 ```yaml
-    win_copy:
-      content: "{{ iis_test_message }}"
-      dest: C:\Inetpub\wwwroot\index.html
+    - name: Create website index.html
+      ansible.windows.win_copy:
+        content: "{{ iis_test_message }}"
+        dest: C:\Inetpub\wwwroot\index.html
 ```
 <!-- {% endraw %} -->
 
@@ -143,8 +147,9 @@ Si vous souhaitez voir l'intégralité du play pour référence, passez au bas d
 
 <!-- {% raw %} -->
 ```yaml
-    debug:
-      msg: http://{{ ansible_host }}
+    - name: Show website address
+      ansible.builtin.debug:
+        msg: http://{{ ansible_host }}
 ```
 <!-- {% endraw %} -->
 
@@ -188,29 +193,29 @@ Vous êtes prêt à automatiser!
 
 <!-- {% raw %} -->
 ```yaml
-    ---
-    - name: install the iis web service
-      hosts: windows
+---
+- name: Install the iis web service
+  hosts: windows
 
-      tasks:
-        - name: install iis
-          win_feature:
-            name: Web-Server
-            state: present
+  tasks:
+    - name: Install iis
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
 
-        - name: start iis service
-          win_service:
-            name: W3Svc
-            state: started
+    - name: Start iis service
+      ansible.windows.win_service:
+        name: W3Svc
+        state: started
 
-        - name: Create website index.html
-          win_copy:
-            content: "{{ iis_test_message }}"
-            dest: C:\Inetpub\wwwroot\index.html
+    - name: Create website index.html
+      ansible.windows.win_copy:
+        content: "{{ iis_test_message }}"
+        dest: C:\Inetpub\wwwroot\index.html
 
-        - name: Show website address
-          debug:
-            msg: http://{{ ansible_host }}
+    - name: Show website address
+      ansible.builtin.debug:
+        msg: http://{{ ansible_host }}
 ```
 <!-- {% endraw %} -->
 <br><br>

--- a/exercises/ansible_windows/5-adv-playbook/README.fr.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.fr.md
@@ -53,18 +53,18 @@ Vous devriez maintenant avoir un éditeur ouvert dans le volet droit qui peut ê
 Ajoutez les paramêtres de votre playbook ainsi que quelques variables. Ceux-ci incluent des packages supplémentaires que vous installerez sur votre serveur Web, ainsi que certaines configurations spécifiques au serveur Web.
 
 ```yaml
-    ---
-    - hosts: windows
-      name: This is a play within a playbook
-      vars:
-        iis_sites:
-          - name: 'Ansible Playbook Test'
-            port: '8080'
-            path: 'C:\sites\playbooktest'
-          - name: 'Ansible Playbook Test 2'
-            port: '8081'
-            path: 'C:\sites\playbooktest2'
-        iis_test_message: "Hello World!  My test IIS Server"
+---
+- name: This is a play within a playbook
+  hosts: windows
+  vars:
+    iis_sites:
+      - name: 'Ansible Playbook Test'
+        port: '8080'
+        path: 'C:\sites\playbooktest'
+      - name: 'Ansible Playbook Test 2'
+        port: '8081'
+        path: 'C:\sites\playbooktest2'
+    iis_test_message: "Hello World!  My test IIS Server"
 ```
 
 Étape 4:
@@ -74,26 +74,26 @@ Ajoutez une nouvelle tâche appelée **installer IIS**. Après avoir écrit le p
 
 <!-- {% raw %} -->
 ```yaml
-      tasks:
-        - name: Install IIS
-          win_feature:
-            name: Web-Server
-            state: present
+  tasks:
+    - name: Install IIS
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
 
-        - name: Create site directory structure
-          win_file:
-            path: "{{ item.path }}"
-            state: directory
-          with_items: "{{ iis_sites }}"
+    - name: Create site directory structure
+      ansible.windows.win_file:
+        path: "{{ item.path }}"
+        state: directory
+      with_items: "{{ iis_sites }}"
 
-        - name: Create IIS site
-          win_iis_website:
-            name: "{{ item.name }}"
-            state: started
-            port: "{{ item.port }}"
-            physical_path: "{{ item.path }}"
-          with_items: "{{ iis_sites }}"
-          notify: restart iis service
+    - name: Create IIS site
+      community.windows.win_iis_website:
+        name: "{{ item.name }}"
+        state: started
+        port: "{{ item.port }}"
+        physical_path: "{{ item.path }}"
+      with_items: "{{ iis_sites }}"
+      notify: restart iis service
 ```
 <!-- {% endraw %} -->
 
@@ -146,29 +146,29 @@ Modifiez votre playbook, `site.yml`, pour ouvrire les ports de votre pare-feu. U
 
 <!-- {% raw %} -->
 ```yaml
-        - name: Open port for site on the firewall
-          win_firewall_rule:
-            name: "iisport{{ item.port }}"
-            enable: yes
-            state: present
-            localport: "{{ item.port }}"
-            action: Allow
-            direction: In
-            protocol: Tcp
-          with_items: "{{ iis_sites }}"
+    - name: Open port for site on the firewall
+      community.windows.win_firewall_rule:
+        name: "iisport{{ item.port }}"
+        enable: true
+        state: present
+        localport: "{{ item.port }}"
+        action: Allow
+        direction: In
+        protocol: Tcp
+      with_items: "{{ iis_sites }}"
 
-        - name: Template simple web site to iis_site_path as index.html
-          win_template:
-            src: 'index.html.j2'
-            dest: '{{ item.path }}\index.html'
-          with_items: "{{ iis_sites }}"
+    - name: Template simple web site to iis_site_path as index.html
+      ansible.windows.win_template:
+        src: 'index.html.j2'
+        dest: '{{ item.path }}\index.html'
+      with_items: "{{ iis_sites }}"
 
-        - name: Show website addresses
-          debug:
-            msg: "{{ item }}"
-          loop:
-            - http://{{ ansible_host }}:8080
-            - http://{{ ansible_host }}:8081
+    - name: Show website addresses
+      ansible.builtin.debug:
+        msg: "{{ item }}"
+      loop:
+        - http://{{ ansible_host }}:8080
+        - http://{{ ansible_host }}:8081
 ```
 <!-- {% endraw %} -->
 
@@ -229,71 +229,72 @@ Jetons maintenant un deuxième coup d'œil pour nous assurer que tout ressemble 
 
 <!-- {% raw %} -->
 ```yaml
-    ---
-    - hosts: windows
-      name: This is a play within a playbook
-      vars:
-        iis_sites:
-          - name: 'Ansible Playbook Test'
-            port: '8080'
-            path: 'C:\sites\playbooktest'
-          - name: 'Ansible Playbook Test 2'
-            port: '8081'
-            path: 'C:\sites\playbooktest2'
-        iis_test_message: "Hello World!  My test IIS Server"
+---
+- hosts: windows
+  name: This is a play within a playbook
+  vars:
+    iis_sites:
+      - name: 'Ansible Playbook Test'
+        port: '8080'
+        path: 'C:\sites\playbooktest'
+      - name: 'Ansible Playbook Test 2'
+        port: '8081'
+        path: 'C:\sites\playbooktest2'
+    iis_test_message: "Hello World!  My test IIS Server"
 
-      tasks:
-        - name: Install IIS
-          win_feature:
-            name: Web-Server
-            state: present
+  tasks:
+    - name: Install IIS
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
 
-        - name: Create site directory structure
-          win_file:
-            path: "{{ item.path }}"
-            state: directory
-          with_items: "{{ iis_sites }}"
+    - name: Create site directory structure
+      ansible.windows.win_file:
+        path: "{{ item.path }}"
+        state: directory
+      with_items: "{{ iis_sites }}"
 
-        - name: Create IIS site
-          win_iis_website:
-            name: "{{ item.name }}"
-            state: started
-            port: "{{ item.port }}"
-            physical_path: "{{ item.path }}"
-          with_items: "{{ iis_sites }}"
-          notify: restart iis service
+    - name: Create IIS site
+      community.windows.win_iis_website:
+        name: "{{ item.name }}"
+        state: started
+        port: "{{ item.port }}"
+        physical_path: "{{ item.path }}"
+      with_items: "{{ iis_sites }}"
+      notify: restart iis service
 
-        - name: Open port for site on the firewall
-          win_firewall_rule:
-            name: "iisport{{ item.port }}"
-            enable: yes
-            state: present
-            localport: "{{ item.port }}"
-            action: Allow
-            direction: In
-            protocol: Tcp
-          with_items: "{{ iis_sites }}"
+    - name: Open port for site on the firewall
+      community.windows.win_firewall_rule:
+        name: "iisport{{ item.port }}"
+        enable: true
+        state: present
+        localport: "{{ item.port }}"
+        action: Allow
+        direction: In
+        protocol: Tcp
+      with_items: "{{ iis_sites }}"
 
-        - name: Template simple web site to iis_site_path as index.html
-          win_template:
-            src: 'index.html.j2'
-            dest: '{{ item.path }}\index.html'
-          with_items: "{{ iis_sites }}"
+    - name: Template simple web site to iis_site_path as index.html
+      ansible.windows.win_template:
+        src: 'index.html.j2'
+        dest: '{{ item.path }}\index.html'
+      with_items: "{{ iis_sites }}"
 
-        - name: Show website addresses
-          debug:
-            msg: "{{ item }}"
-          loop:
-            - http://{{ ansible_host }}:8080
-            - http://{{ ansible_host }}:8081
+    - name: Show website addresses
+      ansible.builtin.debug:
+        msg: "{{ item }}"
+      loop:
+        - http://{{ ansible_host }}:8080
+        - http://{{ ansible_host }}:8081
 
-      handlers:
-        - name: restart iis service
-          win_service:
-            name: W3Svc
-            state: restarted
-            start_mode: auto
+  handlers:
+    - name: Restart iis service
+      ansible.windows.win_service:
+        name: W3Svc
+        state: restarted
+        start_mode: auto
 ```
+
 <!-- {% endraw %} -->
 
 Section 5: Créez un modèle de tache

--- a/exercises/ansible_windows/5-adv-playbook/README.fr.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.fr.md
@@ -288,7 +288,7 @@ Jetons maintenant un deuxième coup d'œil pour nous assurer que tout ressemble 
         - http://{{ ansible_host }}:8081
 
   handlers:
-    - name: Restart iis service
+    - name: restart iis service
       ansible.windows.win_service:
         name: W3Svc
         state: restarted

--- a/exercises/ansible_windows/5-adv-playbook/README.md
+++ b/exercises/ansible_windows/5-adv-playbook/README.md
@@ -244,7 +244,7 @@ Define a handler.
 
 ```yaml
   handlers:
-    - name: Restart iis service
+    - name: restart iis service
       ansible.windows.win_service:
         name: W3Svc
         state: restarted
@@ -351,7 +351,7 @@ intended. If not, now is the time for us to fix it up. The playbook below should
         - http://{{ ansible_host }}:8081
 
   handlers:
-    - name: Restart iis service
+    - name: restart iis service
       ansible.windows.win_service:
         name: W3Svc
         state: restarted

--- a/exercises/ansible_windows/7-win-patch/README.fr.md
+++ b/exercises/ansible_windows/7-win-patch/README.fr.md
@@ -32,14 +32,14 @@ Modifiez le fichier site.yml et ajoutez une définition et quelques tâches à v
 
 <!-- {% raw %} -->
 ```yaml
-    ---
-    - hosts: windows
-      name: This is my Windows patching playbook
-      tasks:
-        - name: Install Windows Updates
-          win_updates:
-            category_names: "{{ categories | default(omit) }}"
-            reboot: '{{ reboot_server | default(true) }}'
+---
+- hosts: windows
+  name: This is my Windows patching playbook
+  tasks:
+    - name: Install Windows Updates
+      win_updates:
+        category_names: "{{ categories | default(omit) }}"
+        reboot: '{{ reboot_server | default(true) }}'
 ```
 <!-- {% endraw %} -->
 


### PR DESCRIPTION
```
##### SUMMARY
In the windows workshops, instructions in french contained issues as most of the playbooks had YAML indendation issues and were not up to date compared to the instructions in english  (it doesn't use FQCN for example)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- exercises
```
