### PR TITLE
EE build fails: add microdnf to ee spec for config_as_code workshop

### DIFF
--- a/exercises/ansible_config_as_code/1-ee/README.md
+++ b/exercises/ansible_config_as_code/1-ee/README.md
@@ -203,6 +203,8 @@ ee_list:
             version: 1.10.3
           - name: community.general
             version: 7.3.0
+    options:
+      package_manager_path: /usr/bin/microdnf
 
 ee_base_image: "{{ ah_host }}/ee-minimal-rhel8:latest"
 ee_image_push: true


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises


##### ADDITIONAL INFORMATION
- ee_list
```
---
ee_list:
  - name: "config_as_code"
    dependencies:
      galaxy:
        collections:
          - name: infra.controller_configuration
            version: 2.5.1
          - name: infra.ah_configuration
            version: 2.0.3
          - name: infra.ee_utilities
            version: 3.1.2
          - name: awx.awx
            version: 22.4.0
          - name: containers.podman
            version: 1.10.3
          - name: community.general
            version: 7.3.0
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- Before
```
    "stdout_lines": [
        "Command that had error:",
        "  podman build -f context/Containerfile -t config_as_code context",
        "...showing last 20 lines of output...",
        "+ PIP_OPTS=",
        "+ install_bindep",
        "+ '[' -f bindep.txt ']'",
        "+ bindep -l newline",
        "+ sort",
        "+ '[' rhel == centos ']'",
        "++ bindep -b compile",
        "++ true",
        "+ compile_packages='podman",
        "python38-pytz",
        "python38-pyyaml",
        "python38-requests'",
        "+ '[' '!' -z 'podman",
        "python38-pytz",
        "python38-pyyaml",
        "python38-requests' ']'",
        "+ /usr/bin/dnf install -y podman python38-pytz python38-pyyaml python38-requests",
        "/output/scripts/assemble: line 75: /usr/bin/dnf: No such file or directory",

```
- After
```
    "msg": "",
    "rc": 0,
    "start": "2023-09-12 12:21:53.444677",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "\u001b[92mComplete! The build context can be found at: /tmp/ansible.rgz5e_a8temp/context\u001b[0m",
    "stdout_lines": [
        "\u001b[92mComplete! The build context can be found at: /tmp/ansible.rgz5e_a8temp/context\u001b[0m"
    ]
}
```