### PR TITLE
Set 'PasswordAuthentication no' in sshd_config for RHEL7 webservers in RIPU workshop

### DIFF
--- a/roles/webservers/tasks/ripu.yml
+++ b/roles/webservers/tasks/ripu.yml
@@ -27,3 +27,35 @@
     baseurl: https://people.redhat.com/bmader/leapp-supplements-demo/RHEL/$releasever/$basearch
     gpgcheck: false
     enabled: false
+
+- name: Gather distribution and distribution_major_version facts
+  ansible.builtin.setup:
+    gather_subset:
+      - '!all'
+      - distribution
+      - distribution_major_version
+
+- name: Code block for sshd_config modification on RHEL7 nodes
+  block:
+    - name: Set PasswordAuthentication no in sshd_config
+      ansible.builtin.lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication'
+        line: "PasswordAuthentication no"
+
+    - name: restart ssh
+      service:
+        name: sshd
+        state: restarted
+
+    - name: Wait 400 seconds (using ansible.builtin.wait_for)
+      ansible.builtin.wait_for:
+        host: "{{ ansible_host }}"
+        timeout: 400
+        port: 22
+      vars:
+        ansible_connection: local
+
+  when:
+    - ansible_distribution == 'RedHat'
+    - ansible_distribution_major_version|int == 7


### PR DESCRIPTION
##### SUMMARY
RHEL In Place Upgrade workshop is moving to utilizing golden AMIs that implement LVM-backed partitions. As a result, the RHEL7 versions of these AMIs need to replicate the sshd_config of RHEL7 AWS Marketplace PayGo AMIs when deployed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
