### PR TITLE
Galaxy NG Role download workaround

### DIFF
--- a/roles/workshop_check_setup/files/security_requirements.yml
+++ b/roles/workshop_check_setup/files/security_requirements.yml
@@ -1,0 +1,8 @@
+---
+roles:
+  - name: ansible_security.ids_config
+    src: https://github.com/ansible-security/ids_config
+  - name: ansible_security.ids_install
+    src: https://github.com/ansible-security/ids_install
+  - name: geerlingguy.repo-epel
+    src: https://github.com/geerlingguy/ansible-role-repo-epel

--- a/roles/workshop_check_setup/tasks/security.yml
+++ b/roles/workshop_check_setup/tasks/security.yml
@@ -8,20 +8,6 @@
 - name: Install required roles
   community.general.ansible_galaxy_install:
     type: role
-    name: "{{ item }}"
+    requirements_file: "{{ role_path }}/files/security_requirements.yml"
     dest: ./workshop_specific/roles/
-  async: 600
-  poll: 0
-  loop:
-    - 'geerlingguy.repo-epel'
-    - 'ansible_security.ids_config'
-    - 'ansible_security.ids_install'
   register: required_role_loop_out
-
-- name: Install required roles | Async
-  ansible.builtin.async_status:
-    jid: "{{ item['ansible_job_id'] }}"
-  loop: "{{ required_role_loop_out['results'] }}"
-  register: job_result
-  until: job_result.finished
-  retries: 30


### PR DESCRIPTION

##### SUMMARY

- The Galaxy NG update has stopped roles from downloading during the security workshop installation.
- This PR adds an ansible-galaxy requirements file and points to the relevant GitHub repository to download the roles.
- 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

