### PR TITLE
change aws tasks to become: false

### DIFF
--- a/provisioner/workshop_specific/ripu.yml
+++ b/provisioner/workshop_specific/ripu.yml
@@ -70,7 +70,7 @@
     controller_projects:
       - name: Project Leapp
         organization: Default
-        scm_update_on_launch: true
+        scm_update_on_launch: false
         scm_update_cache_timeout: 3600
         scm_type: git
         scm_url: "{{ ripu_project_scm_url }}"

--- a/provisioner/workshop_specific/ripu.yml
+++ b/provisioner/workshop_specific/ripu.yml
@@ -153,6 +153,7 @@
           instance-state-name: running
           "tag:Workshop_node1": "{{ec2_name_prefix}}-node1"
       delegate_to: localhost
+      become: false
       register: node1_node_facts
 
     - name: Grab ec2_instance_info for node2
@@ -162,6 +163,7 @@
           instance-state-name: running
           "tag:Workshop_node2": "{{ec2_name_prefix}}-node2"
       delegate_to: localhost
+      become: false
       register: node2_node_facts
 
     - name: Grab ec2_instance_info for node3
@@ -171,6 +173,7 @@
           instance-state-name: running
           "tag:Workshop_node3": "{{ec2_name_prefix}}-node3"
       delegate_to: localhost
+      become: false
       register: node3_node_facts
 
     - name: Grab ec2_instance_info for node4
@@ -180,6 +183,7 @@
           instance-state-name: running
           "tag:Workshop_node4": "{{ec2_name_prefix}}-node4"
       delegate_to: localhost
+      become: false
       register: node4_node_facts
 
     - name: Populate ssh host keys to known_hosts


### PR DESCRIPTION
<!-- PLEASE SUBMIT YOUR PULL REQUEST TO THE `devel` BRANCH AS OUTLINED IN [THE DOCS](https://github.com/ansible/workshops/blob/master/docs/contribute.md#create-a-pull-requests) -->

##### SUMMARY
Provisioning fails with sudo error in my python virtualenv because NOPASSWD is not configured on my localhost. These aws tasks should not be run as root in any case, so I'm adding `become: false`. Now the provisioning works as expected. Task outputs before and after below... 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- provisioner

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
TASK [Grab ec2_instance_info for node1] ************************************
fatal: [bobdev01-student1-ansible-1 -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

After change:
```
TASK [Grab ec2_instance_info for node1] ************************************
ok: [bobdev01-student1-ansible-1 -> localhost]
```