### PR TITLE
Fixes VSCode Server settings.json deprecated ansible-lint setting

### DIFF
--- a/roles/code_server/templates/settings.json
+++ b/roles/code_server/templates/settings.json
@@ -1,6 +1,5 @@
 {
     "git.ignoreLegacyWarning": true,
-    "terminal.integrated.experimentalRefreshOnResume": true,
     "window.menuBarVisibility": "visible",
     "git.enableSmartCommit": true,
     "workbench.tips.enabled": false,
@@ -9,7 +8,7 @@
     "search.smartCase": true,
     "git.confirmSync": false,
     "workbench.colorTheme": "Visual Studio Dark",
-    "ansible.ansibleLint.enabled": false,
+    "ansible.validation.lint.enabled": false,
     "ansible.ansible.useFullyQualifiedCollectionNames": true,
     "files.associations": {
         "*.yml": "ansible"


### PR DESCRIPTION
##### SUMMARY

The settings.json file for vscode server had 2 invalid configurations, most likely as a result of updates to vscode server.  This PR modifies and removes the deprecated values and replaces them where appropriate.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION

The VSCode Ansible extension was not honoring the disabling of ansible lint.  ansible-lint is not installed in the environment so there were errors that vscode couldn't find `ansible-lint'.  Every yaml file that was opened, threw an error as the extension attempted to invoke the linter.  Perhaps this changed in a recent version of the extension.  I found the correct syntax and tested it on a running lab and it successfully disabled linting for ansible files.  All of the errors regarding ansible-lint went away.

In addition to that change, I noticed that there was another depricated value in the settings.json for code server.  The experimentalRefresh is no longer a valid setting, I believe that this is now the default behavior, the setting was marked as invalid on the most recent provision of a lab.

vscode extension
```
Name: Ansible
Id: redhat.ansible
Description: Ansible language support
Version: 2.8.108
Publisher: redhat
VS Marketplace Link: https://open-vsx.org/vscode/item?itemName=redhat.ansible
```


VSCode Server About
```
code-server: v4.11.0
Code: 1.76.1
Commit: 5e805b79fcb6ba4c2d23712967df89a089da575b
Date: 2023-03-14T20:11:32.198Z (8 mos ago)
Browser: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
```
![Screenshot 2023-11-09 at 9 33 40 PM](https://github.com/ansible/workshops/assets/86437966/13f10dde-6335-40c6-b228-458037236085)

![Screenshot 2023-11-09 at 9 35 32 PM](https://github.com/ansible/workshops/assets/86437966/328166aa-4093-4dc7-b160-a9959a7eefca)


