### PR TITLE
podman package: switch to wildcard and insertion of ':' into package name

### DIFF
--- a/provisioner/workshop_specific/auto_satellite.yml
+++ b/provisioner/workshop_specific/auto_satellite.yml
@@ -168,7 +168,7 @@
   tasks:
     - name: update podman package on controllers
       yum:
-        name: "podman>={{ auto_satellite_podman_update_version }}"
+        name: "podman-2{{':'}}{{ auto_satellite_podman_update_version }}*"
         state: present
       when: auto_satellite_podman_update
 


### PR DESCRIPTION
##### SUMMARY
Due to the podman package containing an `:` in it's name, a modification is necessary for how the package name is specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner
