### PR TITLE
fixing sorting logic for populating automation controller

### DIFF
--- a/provisioner/network.yml
+++ b/provisioner/network.yml
@@ -1,8 +1,0 @@
----
-- hosts: student1-rtr1
-  gather_facts: false
-  vars:
-    ansible_libssh_publickey_algorithms: "ssh-rsa"
-  tasks:
-    - name: gather facts
-      cisco.ios.ios_facts:

--- a/provisioner/workshop_specific/auto_satellite.yml
+++ b/provisioner/workshop_specific/auto_satellite.yml
@@ -18,7 +18,11 @@
     TERM: linux
   gather_facts: false
   tasks:
-    - name: Configure satellite admin password
+    - name: include variables for workshops
+      ansible.builtin.include_vars:
+        dir: "../group_vars/"
+
+    - name: configure satellite admin password
       ansible.builtin.command: "foreman-rake permissions:reset password={{ admin_password }}"
 
     - name: Update hammer admin password in /root/.hammer/cli.modules.d/foreman.yml

--- a/provisioner/workshop_specific/auto_satellite.yml
+++ b/provisioner/workshop_specific/auto_satellite.yml
@@ -87,6 +87,40 @@
           register: issue_sat_cert
           until: issue_sat_cert is not failed
           retries: 5
+
+        - name: download LetsEncrypt R3 cert
+          ansible.builtin.get_url:
+            url: https://letsencrypt.org/certs/lets-encrypt-r3.pem
+            dest: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}"
+            mode: 0644
+            checksum: sha256:177e1b8fc43b722b393f4200ff4d92e32deeffbb76fef5ee68d8f49c88cf9d32
+            group: root
+            owner: root
+
+        - name: download LetsEncrypt root X1 cert\
+          ansible.builtin.get_url:
+            url: https://letsencrypt.org/certs/isrgrootx1.pem
+            dest: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}"
+            mode: 0644
+            checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
+            group: root
+            owner: root
+
+        - name: retrieve LetsEncrypt R3 cert
+          ansible.builtin.slurp:
+            src: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}/lets-encrypt-r3.pem"
+          register: intermediate_cert
+
+        - name: retrieve LetsEncrypt root X1 cert
+          ansible.builtin.slurp:
+            src: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}/isrgrootx1.pem"
+          register: root_cert
+
+        - name: combine R3 and root X1 certs to create LetsEncrypt CA bundle
+          ansible.builtin.template:
+            src: cert_bundle.j2
+            dest: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}/letsencrypt-ca-bundle.pem"
+
       rescue:
         - name: Error with SSL cert
           ansible.builtin.debug:
@@ -130,7 +164,7 @@
         src: cert_bundle.j2
         dest: "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix | lower }}.{{ workshop_dns_zone }}/letsencrypt-ca-bundle.pem"
 
-    - name: Start httpd
+    - name: start httpd
       ansible.builtin.service:
         name: httpd.service
         state: started
@@ -152,6 +186,7 @@
         - '"Success!" not in satellite_change_hostname.stdout'
 
     - name: Update satellite with LetsEncrypt cert
+      when: issue_sat_cert is not failed
       ansible.builtin.shell: >-
         satellite-installer --scenario satellite
         --certs-server-cert "/etc/letsencrypt/live/{{ student }}-sat.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}/fullchain.pem"

--- a/roles/issue_cert/tasks/main.yml
+++ b/roles/issue_cert/tasks/main.yml
@@ -10,15 +10,6 @@
         name: certbot
         state: present
         disable_gpg_check: true
-    # solves error
-    # pkg_resources.DistributionNotFound: The 'requests>=2.14.2' distribution was not found and is required by acme
-    # - name: Install requests python package
-    #   pip:
-    #     name: requests>=2.14.2
-
-    # - name: Install requests python package
-    #   pip:
-    #     name: requests>=2.14.2
 
     - &tower-pinger-block
       block:

--- a/roles/populate_controller/tasks/auto_satellite.yml
+++ b/roles/populate_controller/tasks/auto_satellite.yml
@@ -7,9 +7,9 @@
 
 - name: Filter hosts containing student number
   ansible.builtin.set_fact:
-    student_hosts: "{{ groups['rhel'] | select('search', student_number ~ '-') | list }}"
-    control_nodes: "{{ groups['control_nodes'] | select('search', student_number ~ '-') | list }}"
-    satellite_nodes: "{{ groups['satellite'] | select('search', student_number ~ '-') | list }}"
+    student_hosts: "{{ groups['rhel'] | select('search', 'student' ~ student_number ~ '-') | list }}"
+    control_nodes: "{{ groups['control_nodes'] | select('search', 'student' ~ student_number ~ '-') | list }}"
+    satellite_nodes: "{{ groups['satellite'] | select('search', 'student' ~ student_number ~ '-') | list }}"
 
 - name: Debug hosts for
   ansible.builtin.debug:
@@ -95,7 +95,7 @@
   block:
     - name: Filter hosts containing student number
       ansible.builtin.set_fact:
-        centos7_hosts: "{{ groups['centos7'] | select('search', student_number ~ '-') | list }}"
+        centos7_hosts: "{{ groups['centos7'] | select('search', 'student' ~ student_number ~ '-') | list }}"
 
     - name: Add centos7 hosts into controller inventory
       awx.awx.host:

--- a/roles/populate_controller/tasks/network.yml
+++ b/roles/populate_controller/tasks/network.yml
@@ -23,7 +23,7 @@
 
 - name: Filter hosts containing student number
   ansible.builtin.set_fact:
-    student_hosts: "{{ groups['routers'] | select('search', student_number ~ '-') | list }}"
+    student_hosts: "{{ groups['routers'] | select('search', 'student' ~ student_number ~ '-') | list }}"
 
 - name: Debug hosts for 
   ansible.builtin.debug:

--- a/roles/populate_controller/tasks/ripu.yml
+++ b/roles/populate_controller/tasks/ripu.yml
@@ -20,8 +20,8 @@
 
 - name: Filter hosts containing student number
   ansible.builtin.set_fact:
-    student_hosts: "{{ groups['lab_hosts'] | select('search', student_number ~ '-') | list }}"
-    student_control_nodes: "{{ groups['control_nodes'] | select('search', student_number ~ '-') | list }}"
+    student_hosts: "{{ groups['lab_hosts'] | select('search', 'student' ~ student_number ~ '-') | list }}"
+    student_control_nodes: "{{ groups['control_nodes'] | select('search', 'student' ~ student_number ~ '-') | list }}"
 
 - name: Debug hosts for
   ansible.builtin.debug:

--- a/roles/workshop_attendance/templates/nginx.conf.j2
+++ b/roles/workshop_attendance/templates/nginx.conf.j2
@@ -21,6 +21,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
     keepalive_timeout  65;
+    server_names_hash_bucket_size 128;
 
         #gzip  on;
 

--- a/roles/workshop_check_setup/tasks/controller.yml
+++ b/roles/workshop_check_setup/tasks/controller.yml
@@ -7,6 +7,7 @@
 - name: Download manifest.zip
   when:
     - manifest_download_url is defined
+    - not pre_build
   block:
     - name: Enforce use of user/password for manifest download
       ansible.builtin.assert:
@@ -27,6 +28,8 @@
         force_basic_auth: true
 
 - name: check license block
+  when:
+    - not pre_build
   block:
     - name: Check that the manifest.zip exists
       stat:


### PR DESCRIPTION
i know what the problem is! in my code
if i got a bunch of workbenches

```
student_hosts:
  - "dec18-workshop-provision-satellite-student1-node1"
  - "dec18-workshop-provision-satellite-student1-node2"
  - "dec18-workshop-provision-satellite-student1-node3"
  - "dec18-workshop-provision-satellite-student2-node1"
  - "dec18-workshop-provision-satellite-student2-node2"
  - "dec18-workshop-provision-satellite-student2-node3"
  - "dec18-workshop-provision-satellite-student11-node3"
  - "dec18-workshop-provision-satellite-student11-node3"
  - "dec18-workshop-provision-satellite-student11-node3"

student_number: 1
```
i would filter through the giant list of inventory
to sort them “per workbench”

```
- name: Filter hosts containing student number
  ansible.builtin.set_fact:
    student_hosts: "{{ groups['rhel'] | select('search', student_number ~ '-') | list }}"
    control_nodes: "{{ groups['control_nodes'] | select('search', student_number ~ '-') | list }}"
    satellite_nodes: "{{ groups['satellite'] | select('search', student_number ~ '-') | list }}"
```

but this will return student1 AND student11 AND student21 and so on and so forth

if i was just looking for student1
the fix should be

```
new_hosts: "{{ student_hosts | select('search', 'student' ~ student_number ~ '-') | list }}"
```