### PR TITLE
fixing CI system for conditional check

### DIFF
--- a/roles/workshop_check_setup/tasks/main.yml
+++ b/roles/workshop_check_setup/tasks/main.yml
@@ -33,7 +33,7 @@
     test_name_length: "{{ test_name | length }}"
   assert:
     that:
-      - test_name_length <= 65
+      - test_name_length | int <= 65
     msg: "you must make sure your DNS name is shorter"
 
 - name: make sure security_console is set to a correct value

--- a/roles/workshop_check_setup/tasks/main.yml
+++ b/roles/workshop_check_setup/tasks/main.yml
@@ -30,9 +30,10 @@
 - name: make sure DNS name is 65 characters or less
   vars:
     test_name: "studentXXX-code.{{ ec2_name_prefix|lower }}.{{ workshop_dns_zone }}"
+    test_name_length: "{{ test_name | length }}"
   assert:
     that:
-      - "{{ test_name|length }} <= 65"
+      - test_name_length <= 65
     msg: "you must make sure your DNS name is shorter"
 
 - name: make sure security_console is set to a correct value


### PR DESCRIPTION
##### SUMMARY
solving for error in CI "  "msg": "The conditional check '{{ test_name|length }} <= 65' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated.", "


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner

##### ADDITIONAL INFORMATION
n/a
