### PR TITLE
patch for CVE-2023-36845

### DIFF
--- a/roles/configure_routers/tasks/juniper_default.yml
+++ b/roles/configure_routers/tasks/juniper_default.yml
@@ -20,3 +20,15 @@
 
 - name: turn on netconf on port 830
   junipernetworks.junos.junos_netconf:
+
+# disable web-mgmt because of CVE-2023-36845 Feb15 2024
+- name: disable web-management
+  vars:
+    ansible_connection: netconf
+  junipernetworks.junos.junos_config:
+    lines:
+      - delete groups aws-default system services web-management
+    confirm_commit: true
+
+
+


### PR DESCRIPTION
##### SUMMARY
reporting from infosec around CVE vulnerability with Juniper vSRX and their web-mgmt software (also referred to as j-web): https://supportportal.juniper.net/s/article/2023-08-Out-of-Cycle-Security-Bulletin-Junos-OS-SRX-Series-and-EX-Series-Multiple-vulnerabilities-in-J-Web-can-be-combined-to-allow-a-preAuth-Remote-Code-Execution?language=en_US


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
in the future we will also upgrade the Juniper vSRX, but this will require additional testing through all workshop exercises.