### PR TITLE
auto_satellite instance query retry automation for Satellite AMI

### DIFF
--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite.yml
@@ -11,15 +11,6 @@
   include_tasks: ami_find_centos_7.yml
   when: (centos7 is defined) and (centos7 is not none)
 
-- name: find ami for satellite
-  ec2_ami_info:
-    region: "{{ ec2_region }}"
-    owners: "{{ ec2_info['satellite'].owners }}"
-    filters:
-      name: "{{ ec2_info['satellite'].filter }}"
-  register: sat_amis
-
-- name: save ami for satellite
-  set_fact:
-    sat_ami: >
-      {{ sat_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
+- name: Retry loop for find ami for satellite
+  include_tasks: ami_find_auto_satellite_loop.yml
+...

--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite_loop.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_auto_satellite_loop.yml
@@ -1,0 +1,45 @@
+---
+- name: Find ami for satellite Task Group
+  block:
+    - name: Increment retry count
+      ansible.builtin.set_fact:
+        ami_find_subtasks_retry_count: "{{ 0 if ami_find_subtasks_retry_count is undefined else ami_find_subtasks_retry_count | int + 1 }}"
+    # - name: Resume or reset for failed tasks after each failed attempt
+    #   ansible.builtin.include_tasks: some_other_task_resume_or_reset.yml
+    #   when: ami_find_subtasks_retry_count | int != 0
+    - ansible.builtin.debug:
+        msg: "retry count: {{ ami_find_subtasks_retry_count }}"
+
+    - name: Include increasing delay for incremental retries
+      ansible.builtin.command: |
+        python3 -c 'import time;time.sleep({{ ami_find_subtasks_retry_count | int *60 }})'
+      delegate_to: localhost
+      connection: local
+
+    - name: Find ami for satellite
+      amazon.aws.ec2_ami_info:
+        region: "{{ ec2_region }}"
+        owners: "{{ ec2_info['satellite'].owners }}"
+        filters:
+          name: "{{ ec2_info['satellite'].filter }}"
+      register: sat_amis
+
+    - name: Save ami for satellite
+      ansible.builtin.set_fact:
+        sat_ami: >
+          {{ sat_amis.images | selectattr('name', 'defined') | sort(attribute='creation_date') | last }}
+
+  rescue:
+    - name: Maximum retries of grouped tasks reached
+      ansible.builtin.fail:
+        msg: Maximum retries of grouped tasks reached.
+        # initial try plus 4 retries = 5 total tries
+      when: ami_find_subtasks_retry_count | int == 4
+
+    - name: Instrument retry count
+      ansible.builtin.debug:
+        msg: "Task fail retry count: {{ ami_find_subtasks_retry_count }}"
+
+    - name: Loop back via include on this file
+      ansible.builtin.include_tasks: ami_find_auto_satellite_loop.yml
+...


### PR DESCRIPTION
##### SUMMARY
auto_satellite workshop deployment is experiencing spurious failures when querying the EC2 API via supplied AMI filters. This PR introduces a task group retry strategy that loops 5 times, incrementally adding a delay of an additional minute between retries for each failure.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- provisioner
