### PR TITLE
Fix firewall playbook example to not break connection to ansible-1

### DIFF
--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -146,14 +146,14 @@ ok: [node1]
 ok: [node3]
 
 TASK [Install firewalld] *******************************************************
-changed: [ansible-1]
+skipping: [ansible-1]
 changed: [node2]
 changed: [node1]
 changed: [node3]
 
 TASK [Ensure firewalld is running] *********************************************
+skipping: [ansible-1]
 changed: [node3]
-changed: [ansible-1]
 changed: [node2]
 changed: [node1]
 

--- a/exercises/ansible_rhel/1.5-handlers/README.md
+++ b/exercises/ansible_rhel/1.5-handlers/README.md
@@ -89,12 +89,14 @@ Let's say we want to ensure the firewall is configured correctly on all web serv
       ansible.builtin.dnf:
         name: firewalld
         state: present
+      when: inventory_hostname in groups['web']
 
     - name: Ensure firewalld is running
       ansible.builtin.service:
         name: firewalld
         state: started
         enabled: true
+      when: inventory_hostname in groups['web']
 
     - name: Allow HTTPS traffic on web servers
       ansible.posix.firewalld:


### PR DESCRIPTION
##### SUMMARY
The playbook example for setting up the firewall in section 1.5 would install and enable firewalld on ansible-1 but then not configure it. This resulted in a connection error when trying to access the controller UI and VS Code. To fix this, when conditionals were added to only run the firewall related tasks against hosts in the web group.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- exercises

##### ADDITIONAL INFORMATION
If the playbook with the code issue is run it breaks the web connection to the controller (ansible-1). SSH will continue to work allowing the connection to be restored by running `sudo systemctl stop firewalld` on ansible-1.