### PR TITLE
remove security automation workshop from external documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The Red Hat Ansible Automation Workshops project is intended for effectively dem
 | **[Ansible Red Hat Enterprise Linux Workshop](./exercises/ansible_rhel)** <br> focused on automating Linux platforms like Red Hat Enterprise Linux  | [PDF](./decks/ansible_rhel.pdf) | [Google Source](https://docs.google.com/presentation/d/1O2Gj5r_fhjM5Pi5FizrZRInmZ37IlpeKPTP6jSZxEKs/edit?usp=sharing) | [Exercises](./exercises/ansible_rhel)  | `workshop_type: rhel`  |
 | **[Ansible Config as Code Workshop](./exercises/ansible_config_as_code)** <br> focused on config as code for AAP | [PDF](./decks/config_as_code.pdf) | [Google Source](https://docs.google.com/presentation/d/1F6W8p0MG878AC3Q1CsNZHfhX5VkEyGKbwDHACQtoLPI) | [Exercises](./exercises/ansible_config_as_code)   | `workshop_type: configascode` |
 | **[Ansible Network Automation Workshop](./exercises/ansible_network)** <br> focused on router and switch platforms like Arista, Cisco, Juniper   | [PDF](./decks/ansible_network.pdf) | [Google Source](https://docs.google.com/presentation/d/1PIT-kGAGMVEEK8PsuZCoyzFC5CIzLBwdnftnUsdUNWQ/edit?usp=sharing) | [Exercises](./exercises/ansible_network)  | `workshop_type: network`  |
-| **[Ansible Security Automation](./exercises/ansible_security)** <br> focused on automation of security tools like Check Point Firewall, IBM QRadar and the IDS Snort  | [PDF](./decks/ansible_security.pdf) | [Google Source](https://docs.google.com/presentation/d/19gVCBz1BmxC15tDDj-FUlUd_jUUUKay81E8F24cyUjk/edit?usp=sharing) | [Exercises](./exercises/ansible_security)   | `workshop_type: security` |
 | **[Ansible Windows Automation Workshop](./exercises/ansible_windows)** <br> focused on automation of Microsoft Windows  | [PDF](./decks/ansible_windows.pdf) | [Google Source](https://docs.google.com/presentation/d/1RO5CQiCoqLDES1NvTI_1fQrR-oWM1NuW-uB0JRvtJzE) | [Exercises](./exercises/ansible_windows)   | `workshop_type: windows` |
 | **[Smart Management Automation Workshop](./exercises/ansible_smart_mgmt)** <br> focused on automation of  security and lifecycle management with Red Hat Satellite Server | [PDF](./decks/ansible_smart_mgmt.pdf) | [Google Source](https://docs.google.com/presentation/d/135lid9AeSioN4bJexBbv9q0fkJwDibpUQg8aeYjxzTY) | [Exercises](./exercises/ansible_smart_mgmt) | `workshop_type: smart_mgmt`
 | **[RHEL In-place Upgrade Automation Workshop](./exercises/ansible_ripu)** <br> focused on automation of RHEL in-place upgrades at enterprise scale | [PDF](./decks/ansible_ripu.pdf) | [Google Source](https://docs.google.com/presentation/d/1U6i006Th7MQNuL1_0a0KhOSY4GfF1wFsINusDvJvXvo) | [Exercises](./exercises/ansible_ripu) | `workshop_type: ripu`
@@ -77,10 +76,6 @@ The Red Hat Ansible Automation Workshops project is intended for effectively dem
   - ![chinese](https://github.com/ansible/workshops/raw/devel/images/cn.png) [借助红帽实现网络自动化](https://www.redhat.com/rhdc/managed-files/ma-network-automation-technical-e-book-f28378-202104-a4-zh.pdf)
   - ![french](https://github.com/ansible/workshops/raw/devel/images/fr.png) [Automatiser votre réseau avec Red Hat](https://www.redhat.com/rhdc/managed-files/ma-network-automation-technical-e-book-f28378-202104-a4-fr.pdf)
   - ![italian](https://github.com/ansible/workshops/raw/devel/images/it.png) [Automatizzare la rete con Red Hat](https://www.redhat.com/rhdc/managed-files/ma-network-automation-technical-e-book-f28378-202104-a4-it.pdf)
-
-### E-Books for Ansible Security Automation
-
-  - [Simplify your security operations center](https://www.redhat.com/en/resources/security-automation-ebook?extIdCarryOver=true&sc_cid=7013a000002gyQ2AAI)
 
 ---
 ![Red Hat Ansible Automation](https://github.com/ansible/workshops/raw/devel/images/rh-ansible-automation-platform.png)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     gtag('js', new Date());
 
     gtag('config', 'G-LJWQBHM62Z');
-  </script>    
+  </script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -50,15 +50,12 @@
           <a class="header-link" href="{{ '/exercises/ansible_network/' | relative_url }}">
             Network
           </a>
-          <a class="header-link" href="{{ '/exercises/ansible_security/' | relative_url }}">
-            Security
-          </a>
           <a class="header-link" href="{{ '/exercises/ansible_windows/' | relative_url }}">
             Windows
           </a>
           <a class="header-link" href="{{ '/exercises/ansible_config_as_code/' | relative_url }}">
             Config as Code
-          </a>          
+          </a>
           <a class="header-link" href="https://github.com/ansible/workshops/issues/new/choose">
             Open an Issue
           </a>
@@ -79,7 +76,7 @@
               alt="Red Hat"
             />
           </a>
-          <p class="footer-copyright">Copyright © 2022 Red Hat, Inc.</p>
+          <p class="footer-copyright">Copyright © 2024 Red Hat, Inc.</p>
           <div class="footer-linkContainer">
             <a href="https://www.redhat.com/en/about/privacy-policy" class="footer-link">Privacy statement</a>
             <span class="footer-linkSpacer">|</span>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: workshops
-version: 1.0.17
+version: 2.0.0
 readme: README.md
 
 authors:


### PR DESCRIPTION
##### SUMMARY
no one is reading internal documentation so i am making this super clear we are no longer supporting security automation workshop, the exercises and provisioner will remain for anyone that wants to use it ad-hoc on their own time

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Pick one below and delete the rest -->
- exercises
- docs


##### ADDITIONAL INFORMATION
n/a
