### PR TITLE
fixing various issues

### DIFF
--- a/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
+++ b/roles/manage_ec2_instances/tasks/ami_find/ami_find_network.yml
@@ -7,7 +7,7 @@
         region: "{{ ec2_region }}"
         owners: "679593333241"
         filters:
-          name: "Cisco-C8K-17.06.06a-42cb6e93-8d9d-490b-a73c-e3e56077ffd1"
+          name: "Cisco-C8K-17.14.01a-42cb6e93-8d9d-490b-a73c-e3e56077ffd1"
           architecture: "x86_64"
       register: cisco_ami_list
 

--- a/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
+++ b/roles/manage_ec2_instances/tasks/inventory/addhost_network.yml
@@ -40,8 +40,6 @@
     username: "{{ item.tags.Student }}"
     ansible_user: "{{ item.tags.username }}"
     ansible_port: "{{ ssh_port }}"
-    ansible_libssh_publickey_algorithms: "ssh-rsa"
-    ansible_network_cli_ssh_type: libssh
     ansible_ssh_private_key_file: "{{ playbook_dir }}/{{ ec2_name_prefix|lower }}/{{ ec2_name_prefix|lower }}-private.pem"
     private_ip: "{{ item.private_ip_address }}"
     ansible_network_os: "{{ item.tags.ansible_network_os }}"

--- a/roles/manage_ec2_instances/tasks/resources/resources.yml
+++ b/roles/manage_ec2_instances/tasks/resources/resources.yml
@@ -139,6 +139,7 @@
   amazon.aws.ec2_key:
     name: "{{ ec2_name_prefix }}-key"
     region: "{{ ec2_region }}"
+    key_type: "ed25519"
   register: create_key
 
 - name: save private key

--- a/roles/populate_controller/tasks/network.yml
+++ b/roles/populate_controller/tasks/network.yml
@@ -6,7 +6,7 @@
   loop:
     - 'infra.controller_configuration.hosts'
     - 'infra.controller_configuration.organizations'
-    - 'infra.controller_configuration.users'  
+    - 'infra.controller_configuration.users'
     - 'infra.controller_configuration.teams'
     - 'infra.controller_configuration.projects'
     - 'infra.controller_configuration.job_templates'
@@ -16,7 +16,7 @@
     loop_var: setup_controller
 
 - name: Debug the student number via the username var
-  ansible.builtin.debug: 
+  ansible.builtin.debug:
     msg:
      - "student: {{ student_number }}"
      - "{{ groups['routers'] }}"
@@ -25,10 +25,10 @@
   ansible.builtin.set_fact:
     student_hosts: "{{ groups['routers'] | select('search', 'student' ~ student_number ~ '-') | list }}"
 
-- name: Debug hosts for 
+- name: Debug hosts for
   ansible.builtin.debug:
     msg: "{{ student_hosts }}"
-  
+
 - name: Add devices into controller inventory
   awx.awx.host:
     name: "{{ hostvars[item].short_name }}"
@@ -58,7 +58,7 @@
 
 - name: Debug the routers
   debug:
-    msg: 
+    msg:
       - "cisco_routers_short_names: {{ cisco_routers_short_names }}"
       - "arista_routers: {{ arista_routers }}"
       - "juniper_routers: {{ juniper_routers }}"
@@ -73,7 +73,7 @@
     controller_username: admin
     controller_password: "{{ admin_password }}"
     controller_host: "https://{{ ansible_host }}"
-    validate_certs: false    
+    validate_certs: false
 
 - name: Add hosts to juniper
   awx.awx.group:
@@ -85,7 +85,7 @@
     controller_username: admin
     controller_password: "{{ admin_password }}"
     controller_host: "https://{{ ansible_host }}"
-    validate_certs: false    
+    validate_certs: false
 
 - name: Add hosts to arista
   awx.awx.group:
@@ -97,4 +97,36 @@
     controller_username: admin
     controller_password: "{{ admin_password }}"
     controller_host: "https://{{ ansible_host }}"
-    validate_certs: false    
+    validate_certs: false
+
+- name: Add group routers
+  awx.awx.group:
+    name: routers
+    inventory: "Workshop Inventory"
+    children:
+      - cisco
+      - arista
+      - juniper
+    preserve_existing_hosts: True
+    preserve_existing_children: True
+    controller_username: admin
+    controller_password: "{{ admin_password }}"
+    controller_host: "https://{{ ansible_host }}"
+    validate_certs: false
+
+- name: Add group network
+  awx.awx.group:
+    name: network
+    inventory: "Workshop Inventory"
+    children:
+      - routers
+    preserve_existing_hosts: True
+    preserve_existing_children: True
+    variables:
+      restore_inventory: "Workshop Inventory"
+      restore_credential: "Workshop Credential"
+      restore_project: "Workshop Project"
+    controller_username: admin
+    controller_password: "{{ admin_password }}"
+    controller_host: "https://{{ ansible_host }}"
+    validate_certs: false

--- a/roles/populate_controller/vars/network.yml
+++ b/roles/populate_controller/vars/network.yml
@@ -14,7 +14,7 @@ controller_hosts:
     inventory: "Workshop Inventory"
     enabled: true
     variables:
-      ansible_user: "ec2-user"    
+      ansible_user: "ec2-user"
 controller_organizations:
   - name: "Red Hat network organization"
     description: "Red Hat Network Organization"
@@ -177,17 +177,3 @@ controller_groups:
     variables:
       ansible_network_os: junos
       ansible_connection: netconf
-  - name: routers
-    inventory: "Workshop Inventory"
-    children:
-      - cisco
-      - arista
-      - juniper
-  - name: network
-    inventory: "Workshop Inventory"
-    children:
-      - routers
-    variables:
-      restore_inventory: "Workshop Inventory"
-      restore_credential: "Workshop Credential"
-      restore_project: "Workshop Project"


### PR DESCRIPTION
##### SUMMARY
mainly fixing https://github.com/ansible/workshops/issues/2160

- revving from Cisco-C8K-17.06.06a to Cisco-C8K-17.14.01a
- moving from ssh-rsa to ed25519 for all keys since Cisco supports this on 17.10 and later
- solving issue in link above in 2160 where out of order dictionary won't populate the group network
- this also solves where code-server doesn't boot b/c handler would not launch when machine breaks

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- provisioner


##### ADDITIONAL INFORMATION
n/a
